### PR TITLE
Add project origin and technical ownership context

### DIFF
--- a/docs/ASSESSOR_EVIDENCE_SUMMARY.md
+++ b/docs/ASSESSOR_EVIDENCE_SUMMARY.md
@@ -113,6 +113,8 @@ These choices make the system suitable for academic contexts where transparency,
 
 My contribution has been both product-facing and technical. I developed the platform from an initial prototype into a controlled full-stack application by making decisions across frontend structure, backend integration, workflow design, database-backed state, AI function boundaries, deployment, and documentation.
 
+The project began as a rapid AI-assisted prototype, but I later moved it into a GitHub-controlled full-stack codebase and took responsibility for the architecture, Supabase backend, authentication, Edge Functions, AI workflow, testing, CI, documentation, and deployment decisions.
+
 This included:
 
 - designing the student-support and intervention model

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -17,6 +17,14 @@ GradeAI takes a workflow-first approach. Instead of treating AI output as a fina
 
 The goal is to support academic judgement, not replace it.
 
+## Project Origin And Technical Ownership
+
+GradeAI began as a rapid prototype while I was experimenting with AI-assisted development tools. I initially used Lovable to test the product concept quickly and explore whether an AI-assisted academic workflow could be useful for lecturers.
+
+As the idea developed, I recognised the limitations of relying on a generated prototype. I moved the project into a GitHub-controlled full-stack codebase and took responsibility for the architecture, implementation, database model, authentication, Supabase integration, Edge Functions, AI workflow, testing, documentation, CI pipeline, and deployment process.
+
+That transition was important because GradeAI needed to become more than a visual prototype. It needed clear role boundaries, secure data access, human-in-the-loop review, AI response validation, academic integrity safeguards, and a controlled release workflow.
+
 ## Risk Controls And Trust Safeguards
 
 The system includes several controls to reduce the risk of unreliable or misleading AI output.


### PR DESCRIPTION
Adds a clear explanation of the project origin and transition from prototype to full-stack system for assessor clarity.

- Adds "Project Origin And Technical Ownership" section to PROJECT_OVERVIEW
- Adds concise origin note to ASSESSOR_EVIDENCE_SUMMARY

This improves transparency and strengthens technical ownership narrative for reviewers.