### PR TITLE
Harden edge function methods and rate limits

### DIFF
--- a/src/test/edgeFunctionHardening.test.ts
+++ b/src/test/edgeFunctionHardening.test.ts
@@ -139,4 +139,11 @@ describe("edge function hardening", () => {
     expect(source).toContain("cohort_id: z.string().trim().min(1)");
     expect(source).toContain("department_id: z.string().trim().min(1)");
   });
+
+  it("does not append fairness adjustment boilerplate to visible AI feedback", () => {
+    const source = readRepoFile("supabase/functions/grade-submission/index.ts");
+
+    expect(source).not.toContain("Initial AI score was inconsistent with feedback");
+    expect(source).not.toContain("fairness adjustment was applied");
+  });
 });

--- a/src/test/edgeFunctionHardening.test.ts
+++ b/src/test/edgeFunctionHardening.test.ts
@@ -29,6 +29,7 @@ import {
   applyRateLimit,
   resetRateLimitStore,
 } from "../../supabase/functions/_shared/rate-limit";
+import { sanitizeVisibleAiFeedback } from "../../supabase/functions/_shared/visible-feedback";
 
 const readRepoFile = (path: string) => readFileSync(join(process.cwd(), path), "utf8");
 
@@ -140,10 +141,23 @@ describe("edge function hardening", () => {
     expect(source).toContain("department_id: z.string().trim().min(1)");
   });
 
-  it("does not append fairness adjustment boilerplate to visible AI feedback", () => {
-    const source = readRepoFile("supabase/functions/grade-submission/index.ts");
+  it("removes fairness adjustment boilerplate from visible AI feedback", () => {
+    expect(
+      sanitizeVisibleAiFeedback(
+        "Strong evidence and clear structure.\n\nInitial AI score was inconsistent with feedback. A fairness adjustment was applied.",
+      ),
+    ).toBe("Strong evidence and clear structure.");
 
-    expect(source).not.toContain("Initial AI score was inconsistent with feedback");
-    expect(source).not.toContain("fairness adjustment was applied");
+    expect(
+      sanitizeVisibleAiFeedback(
+        "Detailed analysis.\n\n[Initial AI score was inconsistent with feedback. A fairness adjustment was applied.]",
+      ),
+    ).toBe("Detailed analysis.");
+
+    expect(
+      sanitizeVisibleAiFeedback(
+        "Lecturer review recommended: borderline mark.\n\nInitial AI score was inconsistent with UK marking bands. A fairness recalibration was applied and lecturer review is recommended.",
+      ),
+    ).toBe("Lecturer review recommended: borderline mark.");
   });
 });

--- a/src/test/edgeFunctionHardening.test.ts
+++ b/src/test/edgeFunctionHardening.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const { invokeMock, warnMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  warnMock: vi.fn(),
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: {
+      invoke: invokeMock,
+    },
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: {
+    warn: warnMock,
+  },
+}));
+
+import { WorkflowEmailRequestSchema } from "@/lib/communications";
+import { requirePostMethod } from "../../supabase/functions/_shared/http";
+import {
+  applyRateLimit,
+  resetRateLimitStore,
+} from "../../supabase/functions/_shared/rate-limit";
+
+const readRepoFile = (path: string) => readFileSync(join(process.cwd(), path), "utf8");
+
+describe("edge function hardening", () => {
+  beforeEach(() => {
+    resetRateLimitStore();
+  });
+
+  it("returns a 405 JSON response for unsupported methods", async () => {
+    const response = requirePostMethod(
+      new Request("https://gradeai.test/functions/v1/explain-grade", { method: "GET" }),
+      { "Access-Control-Allow-Origin": "https://gradeai.pages.dev" },
+    );
+
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(405);
+    expect(response?.headers.get("Content-Type")).toBe("application/json");
+    expect(response?.headers.get("Allow")).toBe("POST, OPTIONS");
+    await expect(response?.json()).resolves.toEqual({ error: "Method not allowed" });
+  });
+
+  it("allows POST requests through to existing auth and validation paths", () => {
+    const response = requirePostMethod(
+      new Request("https://gradeai.test/functions/v1/explain-grade", { method: "POST" }),
+      {},
+    );
+
+    expect(response).toBeNull();
+  });
+
+  it("keeps auth checks before rate limiting on newly limited functions", () => {
+    for (const file of [
+      "supabase/functions/bulk-create-students/index.ts",
+      "supabase/functions/send-workflow-notification-email/index.ts",
+    ]) {
+      const source = readRepoFile(file);
+      const authIndex = Math.max(source.indexOf("requireLecturer(req)"), source.indexOf("requireUser(req)"));
+      const rateLimitIndex = source.indexOf("applyRateLimit(req");
+
+      expect(authIndex).toBeGreaterThan(-1);
+      expect(rateLimitIndex).toBeGreaterThan(-1);
+      expect(authIndex).toBeLessThan(rateLimitIndex);
+    }
+  });
+
+  it("returns a blocked result for the new bulk student upload rate-limit scope", () => {
+    const req = new Request("https://gradeai.test/functions/v1/bulk-create-students", {
+      headers: { "x-forwarded-for": "203.0.113.20" },
+    });
+
+    applyRateLimit(req, {
+      scope: "bulk-create-students",
+      limit: 1,
+      windowMs: 60_000,
+      userId: "lecturer-1",
+      now: 1_000,
+    });
+    const blocked = applyRateLimit(req, {
+      scope: "bulk-create-students",
+      limit: 1,
+      windowMs: 60_000,
+      userId: "lecturer-1",
+      now: 1_100,
+    });
+
+    expect(blocked.allowed).toBe(false);
+  });
+
+  it("returns a blocked result for the workflow email rate-limit scope", () => {
+    const req = new Request("https://gradeai.test/functions/v1/send-workflow-notification-email", {
+      headers: { "x-forwarded-for": "203.0.113.21" },
+    });
+
+    applyRateLimit(req, {
+      scope: "send-workflow-notification-email",
+      limit: 1,
+      windowMs: 60_000,
+      userId: "lecturer-1",
+      now: 2_000,
+    });
+    const blocked = applyRateLimit(req, {
+      scope: "send-workflow-notification-email",
+      limit: 1,
+      windowMs: 60_000,
+      userId: "lecturer-1",
+      now: 2_100,
+    });
+
+    expect(blocked.allowed).toBe(false);
+  });
+
+  it("keeps the existing workflow email request shape valid", () => {
+    const result = WorkflowEmailRequestSchema.safeParse({
+      category: "grade-released",
+      assignmentId: "6f951f5c-2665-48c8-b404-3ef9b6288882",
+      submissionId: "985386a6-9981-48eb-8277-568b0ec4957f",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("keeps the existing bulk student upload request shape in the edge function schema", () => {
+    const source = readRepoFile("supabase/functions/bulk-create-students/index.ts");
+
+    expect(source).toContain("students: z.array(StudentInputSchema)");
+    expect(source).toContain("email: z.string().trim().email()");
+    expect(source).toContain("name: z.string().trim().min(1)");
+    expect(source).toContain("cohort_id: z.string().trim().min(1)");
+    expect(source).toContain("department_id: z.string().trim().min(1)");
+  });
+});

--- a/src/test/supabaseCors.test.ts
+++ b/src/test/supabaseCors.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { createCorsForbiddenResponse, getCorsHeaders } from "../../supabase/functions/_shared/cors";
+
+function makeRequest(origin: string, method = "POST") {
+  return new Request("https://example.supabase.co/functions/v1/grade-submission", {
+    method,
+    headers: { Origin: origin },
+  });
+}
+
+describe("Supabase shared CORS", () => {
+  it("allows the production Cloudflare Pages domain", () => {
+    const headers = getCorsHeaders(makeRequest("https://gradeai.pages.dev"));
+
+    expect(headers?.["Access-Control-Allow-Origin"]).toBe("https://gradeai.pages.dev");
+  });
+
+  it("allows Cloudflare Pages preview subdomains for this project", () => {
+    const req = makeRequest("https://443e6976.gradeai.pages.dev", "OPTIONS");
+    const headers = getCorsHeaders(req);
+    const response = new Response(null, { headers: headers ?? undefined });
+
+    expect(headers?.["Access-Control-Allow-Origin"]).toBe("https://443e6976.gradeai.pages.dev");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://443e6976.gradeai.pages.dev");
+  });
+
+  it("rejects unrelated pages.dev domains", () => {
+    const headers = getCorsHeaders(makeRequest("https://evil.pages.dev"));
+
+    expect(headers).toBeNull();
+  });
+
+  it("rejects unrelated custom domains", () => {
+    const headers = getCorsHeaders(makeRequest("https://example.com"));
+
+    expect(headers).toBeNull();
+  });
+
+  it("returns a forbidden response for rejected origins", async () => {
+    const response = createCorsForbiddenResponse();
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Origin not allowed" });
+  });
+});

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -6,6 +6,8 @@ const ALLOWED_ORIGINS = new Set([
   "http://127.0.0.1:8080",
 ]);
 
+const PAGES_DEV_ROOT = "gradeai.pages.dev";
+
 const BASE_CORS_HEADERS = {
   "Access-Control-Allow-Headers":
     "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
@@ -21,7 +23,7 @@ export function getCorsHeaders(req: Request): Record<string, string> | null {
     };
   }
 
-  if (!ALLOWED_ORIGINS.has(origin)) {
+  if (!isAllowedOrigin(origin)) {
     return null;
   }
 
@@ -30,6 +32,25 @@ export function getCorsHeaders(req: Request): Record<string, string> | null {
     "Access-Control-Allow-Origin": origin,
     Vary: "Origin",
   };
+}
+
+function isAllowedOrigin(origin: string): boolean {
+  if (ALLOWED_ORIGINS.has(origin)) {
+    return true;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol !== "https:") {
+    return false;
+  }
+
+  return url.hostname.endsWith(`.${PAGES_DEV_ROOT}`);
 }
 
 export function createCorsForbiddenResponse() {

--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -1,0 +1,15 @@
+export function createMethodNotAllowedResponse(corsHeaders: Record<string, string>) {
+  return new Response(JSON.stringify({ error: "Method not allowed" }), {
+    status: 405,
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "application/json",
+      Allow: "POST, OPTIONS",
+    },
+  });
+}
+
+export function requirePostMethod(req: Request, corsHeaders: Record<string, string>) {
+  if (req.method === "POST") return null;
+  return createMethodNotAllowedResponse(corsHeaders);
+}

--- a/supabase/functions/_shared/visible-feedback.ts
+++ b/supabase/functions/_shared/visible-feedback.ts
@@ -1,0 +1,19 @@
+const VISIBLE_FAIRNESS_FEEDBACK_PATTERNS = [
+  /\[?\s*Initial AI score was inconsistent with feedback\.\s*A fairness adjustment was applied\.\s*\]?/gi,
+  /\[?\s*Initial AI score was inconsistent with UK marking bands\.\s*A fairness recalibration was applied and lecturer review is recommended\.\s*\]?/gi,
+];
+
+export function sanitizeVisibleAiFeedback(feedback: string | null | undefined) {
+  const input = typeof feedback === "string" ? feedback : "";
+  if (!input.trim()) return "";
+
+  let sanitized = input;
+  for (const pattern of VISIBLE_FAIRNESS_FEEDBACK_PATTERNS) {
+    sanitized = sanitized.replace(pattern, "");
+  }
+
+  return sanitized
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/supabase/functions/bulk-create-students/index.ts
+++ b/supabase/functions/bulk-create-students/index.ts
@@ -2,7 +2,9 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { z } from "https://esm.sh/zod@3.23.8";
 import { createAdminClient, jsonError, requireLecturer, HttpError } from "../_shared/auth.ts";
 import { createCorsForbiddenResponse, getCorsHeaders } from "../_shared/cors.ts";
-import { logError } from "../_shared/log.ts";
+import { requirePostMethod } from "../_shared/http.ts";
+import { logError, logInfo, logWarn } from "../_shared/log.ts";
+import { applyRateLimit, createRateLimitResponse } from "../_shared/rate-limit.ts";
 
 type StudentInput = {
   name: string;
@@ -35,13 +37,30 @@ serve(async (req) => {
   const corsHeaders = getCorsHeaders(req);
   if (!corsHeaders) return createCorsForbiddenResponse();
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  const methodError = requirePostMethod(req, corsHeaders);
+  if (methodError) return methodError;
 
   try {
-    await requireLecturer(req);
+    const { user } = await requireLecturer(req);
+    const rateLimit = applyRateLimit(req, {
+      scope: "bulk-create-students",
+      limit: 20,
+      windowMs: 60_000,
+      userId: user.id,
+    });
+    if (!rateLimit.allowed) {
+      logWarn("Rate limit exceeded", { function: "bulk-create-students", identifierType: rateLimit.identifierType });
+      return createRateLimitResponse(corsHeaders, rateLimit.retryAfterSeconds);
+    }
+
     const body = await req.json().catch(() => null);
     const parsed = BulkCreateStudentsRequestSchema.safeParse(body);
 
     if (!parsed.success) {
+      logWarn("Invalid bulk student upload request", {
+        function: "bulk-create-students",
+        issueCount: parsed.error.issues.length,
+      });
       return new Response(
         JSON.stringify({
           error: "Invalid request format",
@@ -99,6 +118,14 @@ serve(async (req) => {
 
       results.push({ name, email, password, success: true });
     }
+
+    const successCount = results.filter((result) => result.success).length;
+    logInfo("bulk-create-students completed", {
+      function: "bulk-create-students",
+      requestedCount: students.length,
+      successCount,
+      failedCount: results.length - successCount,
+    });
 
     return new Response(JSON.stringify({ results }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },

--- a/supabase/functions/check-plagiarism/index.ts
+++ b/supabase/functions/check-plagiarism/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { z } from "https://esm.sh/zod@3.23.8";
 import { createAdminClient, jsonError, requireLecturer, HttpError } from "../_shared/auth.ts";
 import { createCorsForbiddenResponse, getCorsHeaders } from "../_shared/cors.ts";
+import { requirePostMethod } from "../_shared/http.ts";
 import { logError, logInfo, logWarn } from "../_shared/log.ts";
 import {
   DOCUMENT_EXTRACTION_ERROR_MESSAGE,
@@ -716,6 +717,8 @@ serve(async (req) => {
   const corsHeaders = getCorsHeaders(req);
   if (!corsHeaders) return createCorsForbiddenResponse();
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  const methodError = requirePostMethod(req, corsHeaders);
+  if (methodError) return methodError;
 
   try {
     const startedAt = Date.now();

--- a/supabase/functions/explain-grade/index.ts
+++ b/supabase/functions/explain-grade/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { z } from "https://esm.sh/zod@3.23.8";
 import { jsonError, requireUser } from "../_shared/auth.ts";
 import { createCorsForbiddenResponse, getCorsHeaders } from "../_shared/cors.ts";
+import { requirePostMethod } from "../_shared/http.ts";
 import { logError, logWarn } from "../_shared/log.ts";
 import { createChatCompletion, getModel } from "../_shared/openai.ts";
 import { applyRateLimit, createRateLimitResponse } from "../_shared/rate-limit.ts";
@@ -32,6 +33,8 @@ serve(async (req) => {
   const corsHeaders = getCorsHeaders(req);
   if (!corsHeaders) return createCorsForbiddenResponse();
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  const methodError = requirePostMethod(req, corsHeaders);
+  if (methodError) return methodError;
 
   try {
     const { user } = await requireUser(req);

--- a/supabase/functions/grade-submission/index.ts
+++ b/supabase/functions/grade-submission/index.ts
@@ -2218,13 +2218,6 @@ Return corrected JSON only.`;
         if (stabilityNotes.length > 0) {
           feedbackParts.push(stabilityNotes[stabilityNotes.length - 1]);
         }
-        if (recalibrationApplied) {
-          feedbackParts.push(
-            fairnessRecalibrationApplied
-              ? "Initial AI score was inconsistent with UK marking bands. A fairness recalibration was applied and lecturer review is recommended."
-              : "Initial AI score was inconsistent with feedback. A fairness adjustment was applied.",
-          );
-        }
         if (requiresLecturerReview && reviewReasons.length > 0) {
           feedbackParts.push(`Lecturer review recommended: ${Array.from(new Set(reviewReasons)).join("; ")}`);
         }

--- a/supabase/functions/grade-submission/index.ts
+++ b/supabase/functions/grade-submission/index.ts
@@ -12,6 +12,7 @@ import {
 import { createResponse, extractOutputText, getModel, parseJsonText } from "../_shared/openai.ts";
 import { applyRateLimit, createRateLimitResponse } from "../_shared/rate-limit.ts";
 import { classifyAssignmentType, type AssignmentType } from "../_shared/text-analysis.ts";
+import { sanitizeVisibleAiFeedback } from "../_shared/visible-feedback.ts";
 
 const CONFIDENCE_THRESHOLD = 0.7;
 const REGRADING_DRIFT_THRESHOLD_RATIO = 0.08;
@@ -1638,10 +1639,11 @@ serve(async (req) => {
         if (cacheHit) {
           const cachedBreakdown = normalizeBreakdown(existingGrade.ai_breakdown, normalizedRubric);
           const cachedConfidence = clampConfidence(existingGrade.grading_confidence ?? existingMetadata.confidence_score);
+          const cachedFeedback = sanitizeVisibleAiFeedback(existingGrade.ai_feedback);
           const cachedResult = {
             submissionId: sub.id,
             score: Number(existingGrade.ai_score),
-            feedback: existingGrade.ai_feedback || "Using saved AI marking result.",
+            feedback: cachedFeedback || "Using saved AI marking result.",
             breakdown: cachedBreakdown.breakdown,
             assignmentType: classifyAssignmentType({
               title: assignment.title,
@@ -1777,10 +1779,11 @@ serve(async (req) => {
           const clusterMismatch =
             (matchingExistingFingerprintCluster?.gradeCount || 0) > 1 &&
             (matchingExistingFingerprintCluster?.scoreSpread || 0) > 0;
+          const reusedFeedback = sanitizeVisibleAiFeedback(matchingExistingFingerprintGrade.ai_feedback);
           results.push({
             submissionId: sub.id,
             score: Number(matchingExistingFingerprintGrade.ai_score),
-            feedback: `${matchingExistingFingerprintGrade.ai_feedback || "Reused existing AI grade for identical content."}\n\nIdentical blinded content matched a previously graded submission in this assignment. Reused the canonical cluster grade for consistency.${clusterMismatch ? ` Historical duplicate grades for this same content varied by ${matchingExistingFingerprintCluster?.scoreSpread} marks, so the canonical cluster grade was applied and lecturer review is recommended.` : ""}`,
+            feedback: `${reusedFeedback || "Reused existing AI grade for identical content."}\n\nIdentical blinded content matched a previously graded submission in this assignment. Reused the canonical cluster grade for consistency.${clusterMismatch ? ` Historical duplicate grades for this same content varied by ${matchingExistingFingerprintCluster?.scoreSpread} marks, so the canonical cluster grade was applied and lecturer review is recommended.` : ""}`,
             breakdown: reusedBreakdown.breakdown,
             assignmentType: classifyAssignmentType({
               title: assignment.title,
@@ -2006,7 +2009,7 @@ Return corrected JSON only.`;
             }
             modelScore = previousAiScore;
             modelFeedback =
-              existingGrade?.ai_feedback?.trim() ||
+              sanitizeVisibleAiFeedback(existingGrade?.ai_feedback?.trim()) ||
               "Previous AI grade preserved because repeated regrading produced materially different scores for the same submission.";
             gradingConfidence = Math.min(clampConfidence(existingGrade?.grading_confidence), 0.65);
             regradeVariancePreservedPrior = true;
@@ -2208,7 +2211,7 @@ Return corrected JSON only.`;
           regradeVariancePreservedPrior ||
           isNearGradeBoundary(normalized.total, assignment.max_score);
 
-        const feedbackParts = [modelFeedback];
+        const feedbackParts = [sanitizeVisibleAiFeedback(modelFeedback)];
         if (scoreAdjusted) {
           feedbackParts.push("Final score was recalculated to match the exact sum of criterion scores.");
         }
@@ -2221,6 +2224,7 @@ Return corrected JSON only.`;
         if (requiresLecturerReview && reviewReasons.length > 0) {
           feedbackParts.push(`Lecturer review recommended: ${Array.from(new Set(reviewReasons)).join("; ")}`);
         }
+        const visibleFeedback = sanitizeVisibleAiFeedback(feedbackParts.filter(Boolean).join("\n\n"));
 
         const gradingHistory =
           existingGrade?.ai_score != null || forceRegenerate || existingHash !== gradingInputHash
@@ -2243,7 +2247,7 @@ Return corrected JSON only.`;
         results.push({
           submissionId: sub.id,
           score: normalized.total,
-          feedback: feedbackParts.join("\n\n"),
+          feedback: visibleFeedback,
           breakdown: normalized.breakdown,
           assignmentType,
           gradingConfidence,
@@ -2284,7 +2288,7 @@ Return corrected JSON only.`;
         });
         generatedResultsByFingerprint.set(gradingInputHash, {
           score: normalized.total,
-          feedback: feedbackParts.join("\n\n"),
+          feedback: visibleFeedback,
           breakdown: normalized.breakdown,
           assignmentType,
           gradingConfidence,

--- a/supabase/functions/grade-submission/index.ts
+++ b/supabase/functions/grade-submission/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { z } from "https://esm.sh/zod@3.23.8";
 import { createAdminClient, jsonError, requireLecturer, HttpError } from "../_shared/auth.ts";
 import { createCorsForbiddenResponse, getCorsHeaders } from "../_shared/cors.ts";
+import { requirePostMethod } from "../_shared/http.ts";
 import { logError, logInfo, logWarn } from "../_shared/log.ts";
 import {
   DOCUMENT_EXTRACTION_ERROR_MESSAGE,
@@ -1390,6 +1391,8 @@ serve(async (req) => {
   const corsHeaders = getCorsHeaders(req);
   if (!corsHeaders) return createCorsForbiddenResponse();
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  const methodError = requirePostMethod(req, corsHeaders);
+  if (methodError) return methodError;
 
   try {
     const { user } = await requireLecturer(req);

--- a/supabase/functions/send-workflow-notification-email/index.ts
+++ b/supabase/functions/send-workflow-notification-email/index.ts
@@ -6,7 +6,9 @@ import {
   requireUser,
 } from "../_shared/auth.ts";
 import { createCorsForbiddenResponse, getCorsHeaders } from "../_shared/cors.ts";
+import { requirePostMethod } from "../_shared/http.ts";
 import { logWarn } from "../_shared/log.ts";
+import { applyRateLimit, createRateLimitResponse } from "../_shared/rate-limit.ts";
 import {
   formatAssignmentPublishedEmail,
   formatGradeReleasedEmail,
@@ -75,9 +77,25 @@ serve(async (req) => {
   const corsHeaders = getCorsHeaders(req);
   if (!corsHeaders) return createCorsForbiddenResponse();
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  const methodError = requirePostMethod(req, corsHeaders);
+  if (methodError) return methodError;
 
   try {
     const { user } = await requireUser(req);
+    const rateLimit = applyRateLimit(req, {
+      scope: "send-workflow-notification-email",
+      limit: 120,
+      windowMs: 60_000,
+      userId: user.id,
+    });
+    if (!rateLimit.allowed) {
+      logWarn("Rate limit exceeded", {
+        function: "send-workflow-notification-email",
+        identifierType: rateLimit.identifierType,
+      });
+      return createRateLimitResponse(corsHeaders, rateLimit.retryAfterSeconds);
+    }
+
     const admin = createAdminClient();
     const rawBody = await req.json().catch(() => null);
     const parsed = RequestSchema.safeParse(rawBody);


### PR DESCRIPTION
## Summary

Phase 1 hardening for Supabase Edge Functions while preserving current live testing behaviour.

- Added shared POST method enforcement for mutating/AI Edge Functions
- Added explicit 405 JSON responses for unsupported methods while preserving OPTIONS handling
- Added in-memory rate limiting to bulk-create-students and send-workflow-notification-email
- Kept existing frontend payloads, grading logic, plagiarism logic, moderation logic, RLS, database schema, and persistent rate limiting unchanged
- Added safe logging for bulk uploads using counts only, without student passwords or private data
- Added/updated edge function hardening tests

## Verification

- npm run lint passed
- npm run test passed: 38 files, 158 tests
- npm run build passed
- Supabase functions deployed successfully to project nyhisxovomznzldafgtz

## Behaviour changes

- Non-POST methods now return 405 JSON instead of falling through to auth/body parsing
- Authenticated users exceeding generous bulk/email limits now receive 429 Too many requests
- Missing auth on POST still follows the existing auth path and remains 401