### PR TITLE
Load explain-grade context server-side

### DIFF
--- a/src/pages/dashboard/ExplainGrade.tsx
+++ b/src/pages/dashboard/ExplainGrade.tsx
@@ -334,8 +334,8 @@ const ExplainGrade = () => {
           Authorization: `Bearer ${accessToken}`,
         },
         body: JSON.stringify({
+          submissionId: selected.submissionId,
           messages: updatedMessages.map((m) => ({ role: m.role, content: m.content })),
-          gradeContext: gradeBreakdown,
         }),
       });
 

--- a/src/pages/dashboard/ExplainGrade.tsx
+++ b/src/pages/dashboard/ExplainGrade.tsx
@@ -52,6 +52,14 @@ interface AssignmentRow {
   title: string;
 }
 
+interface AssignmentMetadataRow {
+  assignment_id: string;
+  max_score: number | null;
+  module_code: string | null;
+  submission_id: string;
+  title: string | null;
+}
+
 type ExplainGradeBreakdownItem = AcademicGradeBreakdownItem & SharedGradeBreakdown;
 
 export const getBreakdownMaxScore = (item: ExplainGradeBreakdownItem) => item.max_score ?? item.maxScore ?? 0;
@@ -248,10 +256,7 @@ const ExplainGrade = () => {
       const { data: grades } = subIds.length > 0
         ? await supabase.from("grades").select("*").in("submission_id", subIds)
         : { data: [] as GradeRow[] };
-      const assignmentIds = [...new Set(submissionRows.map((submission) => submission.assignment_id))];
-      const { data: assignments } = assignmentIds.length > 0
-        ? await supabase.from("assignments").select("*").in("id", assignmentIds)
-        : { data: [] as AssignmentRow[] };
+      const assignmentMetaRes = await supabase.rpc("get_student_grade_assignment_metadata");
 
       if (!grades?.length || !releasedSubs.length) {
         setLoading(false);
@@ -259,9 +264,15 @@ const ExplainGrade = () => {
       }
 
       const safeSubs = releasedSubs;
-      const safeAssignments = (assignments ?? []) as AssignmentRow[];
       const subMap = Object.fromEntries(safeSubs.map(s => [s.id, s]));
-      const assignMap = Object.fromEntries(safeAssignments.map(a => [a.id, a]));
+      const assignmentMap: Record<string, AssignmentMetadataRow> = {};
+      if (assignmentMetaRes.error) {
+        log.warn("ExplainGrade assignment metadata lookup failed", assignmentMetaRes.error);
+      } else {
+        ((assignmentMetaRes.data ?? []) as AssignmentMetadataRow[]).forEach((row) => {
+          assignmentMap[row.submission_id] = row;
+        });
+      }
 
       const options: SubmissionOption[] = grades
         .flatMap(g => {
@@ -276,7 +287,7 @@ const ExplainGrade = () => {
           }
 
           const sub = subMap[g.submission_id];
-          const assignment = sub ? assignMap[sub.assignment_id] : null;
+          const assignment = assignmentMap[g.submission_id];
           const totalGrade = Number(g.final_score ?? g.ai_score ?? 0);
           const breakdown: ExplainGradeBreakdownItem[] = breakdownResult.data;
           const totalMaxRaw = breakdown.reduce((s: number, b: ExplainGradeBreakdownItem) => s + getBreakdownMaxScore(b), 0);

--- a/src/pages/dashboard/ExplainGrade.tsx
+++ b/src/pages/dashboard/ExplainGrade.tsx
@@ -34,6 +34,8 @@ interface SubmissionRow {
   student_name: string | null;
   file_name: string | null;
   status?: string | null;
+  released_at?: string | null;
+  updated_at?: string | null;
 }
 
 interface GradeRow {
@@ -84,9 +86,46 @@ interface SubmissionOption {
   gradeId: string;
   submissionId: string;
   label: string;
+  secondaryLabel: string | null;
   totalGrade: number;
   breakdown: ExplainGradeBreakdown;
 }
+
+const formatReleasedDate = (value?: string | null) => {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(date);
+};
+
+export const buildGradeSelectorLabels = ({
+  assignmentTitle,
+  fileName,
+  releasedAt,
+  score,
+}: {
+  assignmentTitle?: string | null;
+  fileName?: string | null;
+  releasedAt?: string | null;
+  score: number;
+}) => {
+  const title = assignmentTitle?.trim();
+  const file = fileName?.trim();
+  const primaryBase = title || file || "Released grade";
+  const releasedDate = formatReleasedDate(releasedAt);
+  const secondaryParts = [file, releasedDate ? `Released ${releasedDate}` : null].filter(Boolean);
+
+  return {
+    label: `${primaryBase} — ${score}%`,
+    assessment: primaryBase,
+    secondaryLabel: secondaryParts.length > 0 ? secondaryParts.join(" · ") : null,
+  };
+};
 
 const DEMO_SUBMISSIONS: SubmissionOption[] = Object.values(DEMO_STUDENT_ASSIGNMENT_SUBMISSIONS)
   .flat()
@@ -132,18 +171,21 @@ const DEMO_SUBMISSIONS: SubmissionOption[] = Object.values(DEMO_STUDENT_ASSIGNME
         };
       });
 
-    const label = assignment
-      ? `${assignment.module_code || ""} ${assignment.title}`.trim()
-      : submission.file_name;
+    const labels = buildGradeSelectorLabels({
+      assignmentTitle: assignment?.title,
+      fileName: submission.file_name,
+      score: totalGrade,
+    });
 
     return [
       {
         gradeId: grade.id,
         submissionId: submission.id,
-        label,
+        label: labels.label,
+        secondaryLabel: labels.secondaryLabel,
         totalGrade,
         breakdown: {
-          assessment: label,
+          assessment: labels.assessment,
           totalGrade,
           band: getBand(totalGrade),
           components,
@@ -273,17 +315,21 @@ const ExplainGrade = () => {
               };
             });
 
-          const label = assignment
-            ? `${assignment.module_code || ""} ${assignment.title}`.trim()
-            : sub?.student_name || sub?.file_name || g.submission_id;
+          const labels = buildGradeSelectorLabels({
+            assignmentTitle: assignment?.title,
+            fileName: sub?.file_name,
+            releasedAt: sub?.released_at ?? sub?.updated_at,
+            score: totalGrade,
+          });
 
           return [{
             gradeId: g.id,
             submissionId: g.submission_id,
-            label,
+            label: labels.label,
+            secondaryLabel: labels.secondaryLabel,
             totalGrade,
             breakdown: {
-              assessment: label,
+              assessment: labels.assessment,
               totalGrade,
               band: getBand(totalGrade),
               components,
@@ -435,8 +481,13 @@ const ExplainGrade = () => {
           <SelectTrigger className="w-full"><SelectValue placeholder="Select a submission" /></SelectTrigger>
           <SelectContent>
             {submissions.map(s => (
-              <SelectItem key={s.gradeId} value={s.gradeId}>
-                {s.label} — {s.totalGrade}%
+              <SelectItem key={s.gradeId} value={s.gradeId} textValue={s.label}>
+                <span className="flex flex-col">
+                  <span>{s.label}</span>
+                  {s.secondaryLabel && (
+                    <span className="text-xs text-muted-foreground">{s.secondaryLabel}</span>
+                  )}
+                </span>
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/test/ExplainGrade.test.tsx
+++ b/src/test/ExplainGrade.test.tsx
@@ -200,6 +200,7 @@ describe("ExplainGrade", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
     mocks.authState.isDemo = false;
     mocks.authState.user = { id: "student-1" };
   });
@@ -388,5 +389,41 @@ describe("ExplainGrade", () => {
     expect(screen.queryByText("Grade Breakdown")).not.toBeInTheDocument();
 
     consoleError.mockRestore();
+  });
+
+  it("sends submissionId and messages without browser gradeContext", async () => {
+    setupSupabase();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(
+                'data: {"choices":[{"delta":{"content":"Use the released feedback."}}]}\n\ndata: [DONE]\n\n',
+              ),
+            );
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderExplainGrade();
+
+    expect(await screen.findByText("Grade Breakdown")).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText("Ask about your grade..."), {
+      target: { value: "How can I improve?" },
+    });
+    fireEvent.click(screen.getAllByRole("button").at(-1)!);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+
+    expect(requestBody.submissionId).toBe("submission-1");
+    expect(requestBody.messages.at(-1)).toEqual({ role: "user", content: "How can I improve?" });
+    expect(requestBody.gradeContext).toBeUndefined();
+    expect(JSON.stringify(requestBody)).not.toContain("Argument");
   });
 });

--- a/src/test/ExplainGrade.test.tsx
+++ b/src/test/ExplainGrade.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import ExplainGrade, { getBreakdownMaxScore } from "@/pages/dashboard/ExplainGrade";
+import ExplainGrade, { buildGradeSelectorLabels, getBreakdownMaxScore } from "@/pages/dashboard/ExplainGrade";
 
 const mocks = vi.hoisted(() => ({
   authState: {
@@ -58,6 +58,8 @@ type SubmissionRow = {
   student_name?: string | null;
   file_name?: string | null;
   status?: string | null;
+  released_at?: string | null;
+  updated_at?: string | null;
 };
 
 type GradeRow = {
@@ -220,7 +222,7 @@ describe("ExplainGrade", () => {
     renderExplainGrade();
 
     expect(await screen.findByText("Grade Breakdown")).toBeInTheDocument();
-    expect(screen.getByText("ENG101 Critical Essay")).toBeInTheDocument();
+    expect(screen.getByText("Critical Essay")).toBeInTheDocument();
     expect(screen.getByText("74%")).toBeInTheDocument();
   });
 
@@ -232,7 +234,7 @@ describe("ExplainGrade", () => {
     expect(await screen.findByText("Grade Breakdown")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "EDU401 Evaluating the Role of Artificial Intelligence in University Assessment and Student Support",
+        "Evaluating the Role of Artificial Intelligence in University Assessment and Student Support",
       ),
     ).toBeInTheDocument();
 
@@ -312,10 +314,107 @@ describe("ExplainGrade", () => {
 
     renderExplainGrade();
 
-    expect(await screen.findByText("ENG101 Critical Essay")).toBeInTheDocument();
+    expect(await screen.findByText("Critical Essay")).toBeInTheDocument();
     expect(screen.getByText("How to Improve")).toBeInTheDocument();
     expect(screen.getByText("Specific guidance to raise your grade band")).toBeInTheDocument();
     expect(screen.queryByText("Draft Essay")).not.toBeInTheDocument();
+  });
+
+  it("builds grade selector labels without using the student name", () => {
+    expect(
+      buildGradeSelectorLabels({
+        assignmentTitle: "Data Structures Assignment",
+        fileName: "Nkechi Onwumere CV.docx",
+        releasedAt: "2026-04-29T10:00:00.000Z",
+        score: 67,
+      }),
+    ).toEqual({
+      label: "Data Structures Assignment — 67%",
+      assessment: "Data Structures Assignment",
+      secondaryLabel: "Nkechi Onwumere CV.docx · Released 29 Apr 2026",
+    });
+
+    expect(
+      buildGradeSelectorLabels({
+        assignmentTitle: null,
+        fileName: "fallback-report.pdf",
+        score: 58,
+      }),
+    ).toMatchObject({
+      label: "fallback-report.pdf — 58%",
+      assessment: "fallback-report.pdf",
+    });
+
+    expect(
+      buildGradeSelectorLabels({
+        assignmentTitle: "",
+        fileName: null,
+        score: 41,
+      }),
+    ).toMatchObject({
+      label: "Released grade — 41%",
+      assessment: "Released grade",
+    });
+  });
+
+  it("uses assignment title and score as the rendered grade selector main label", async () => {
+    setupSupabase({
+      submissions: [
+        {
+          id: "submission-1",
+          assignment_id: "assignment-1",
+          student_name: "abdullahi faruk",
+          file_name: "Nkechi Onwumere CV.docx",
+          status: "released",
+          updated_at: "2026-04-29T10:00:00.000Z",
+        },
+        {
+          id: "submission-2",
+          assignment_id: null,
+          student_name: "Other Student",
+          file_name: "fallback-report.pdf",
+          status: "released",
+          updated_at: "2026-04-28T10:00:00.000Z",
+        },
+        {
+          id: "submission-3",
+          assignment_id: null,
+          student_name: "Hidden Student",
+          file_name: null,
+          status: "released",
+        },
+      ],
+      grades: [
+        {
+          id: "grade-1",
+          submission_id: "submission-1",
+          final_score: 67,
+          ai_breakdown: [{ criterion: "Correctness", score: 17, max_score: 25 }],
+        },
+        {
+          id: "grade-2",
+          submission_id: "submission-2",
+          final_score: 58,
+          ai_breakdown: [{ criterion: "Analysis", score: 15, max_score: 25 }],
+        },
+        {
+          id: "grade-3",
+          submission_id: "submission-3",
+          final_score: 41,
+          ai_breakdown: [{ criterion: "Evidence", score: 10, max_score: 25 }],
+        },
+      ],
+      assignments: [{ id: "assignment-1", module_code: "CS201", title: "Data Structures Assignment" }],
+    });
+
+    renderExplainGrade();
+
+    expect(await screen.findByText("Data Structures Assignment")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveTextContent("Data Structures Assignment — 67%");
+    expect(screen.getByRole("combobox")).toHaveTextContent("Nkechi Onwumere CV.docx · Released 29 Apr 2026");
+    expect(screen.queryByText(/abdullahi faruk/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Other Student/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Hidden Student/i)).not.toBeInTheDocument();
   });
 
   it("shows safe student guidance without exposing provisional or unreleased grading data", async () => {

--- a/src/test/ExplainGrade.test.tsx
+++ b/src/test/ExplainGrade.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   },
   supabase: {
     from: vi.fn(),
+    rpc: vi.fn(),
     auth: {
       getSession: vi.fn(),
     },
@@ -82,6 +83,14 @@ type AssignmentRow = {
   title: string;
 };
 
+type AssignmentMetadataRow = {
+  assignment_id: string;
+  max_score: number | null;
+  module_code: string | null;
+  submission_id: string;
+  title: string | null;
+};
+
 type Deferred<T> = {
   promise: Promise<T>;
   resolve: (value: T) => void;
@@ -131,21 +140,39 @@ const defaultAssignments: AssignmentRow[] = [
   },
 ];
 
+const defaultAssignmentMetadata: AssignmentMetadataRow[] = [
+  {
+    assignment_id: "assignment-1",
+    max_score: 100,
+    module_code: "ENG101",
+    submission_id: "submission-1",
+    title: "Critical Essay",
+  },
+];
+
 const setupSupabase = ({
   submissions = defaultSubmissions,
   grades = defaultGrades,
   assignments = defaultAssignments,
+  assignmentMetadata = defaultAssignmentMetadata,
+  assignmentMetadataError = null,
   submissionsPromise,
   submissionsError,
 }: {
   submissions?: SubmissionRow[];
   grades?: GradeRow[];
   assignments?: AssignmentRow[];
+  assignmentMetadata?: AssignmentMetadataRow[];
+  assignmentMetadataError?: { message: string } | null;
   submissionsPromise?: Promise<{ data: SubmissionRow[] }>;
   submissionsError?: Error;
 } = {}) => {
   mocks.supabase.auth.getSession.mockResolvedValue({
     data: { session: { access_token: "test-token" } },
+  });
+  mocks.supabase.rpc.mockResolvedValue({
+    data: assignmentMetadata,
+    error: assignmentMetadataError,
   });
 
   mocks.supabase.from.mockImplementation((table: string) => ({
@@ -404,7 +431,16 @@ describe("ExplainGrade", () => {
           ai_breakdown: [{ criterion: "Evidence", score: 10, max_score: 25 }],
         },
       ],
-      assignments: [{ id: "assignment-1", module_code: "CS201", title: "Data Structures Assignment" }],
+      assignments: [],
+      assignmentMetadata: [
+        {
+          assignment_id: "assignment-1",
+          max_score: 100,
+          module_code: "CS201",
+          submission_id: "submission-1",
+          title: "Data Structures Assignment",
+        },
+      ],
     });
 
     renderExplainGrade();
@@ -412,9 +448,50 @@ describe("ExplainGrade", () => {
     expect(await screen.findByText("Data Structures Assignment")).toBeInTheDocument();
     expect(screen.getByRole("combobox")).toHaveTextContent("Data Structures Assignment — 67%");
     expect(screen.getByRole("combobox")).toHaveTextContent("Nkechi Onwumere CV.docx · Released 29 Apr 2026");
+    expect(mocks.supabase.rpc).toHaveBeenCalledWith("get_student_grade_assignment_metadata");
     expect(screen.queryByText(/abdullahi faruk/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Other Student/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Hidden Student/i)).not.toBeInTheDocument();
+  });
+
+  it("falls back to file name when assignment title metadata is unavailable", async () => {
+    setupSupabase({
+      submissions: [
+        {
+          id: "submission-1",
+          assignment_id: "assignment-1",
+          student_name: "Sam Student",
+          file_name: "fallback-report.pdf",
+          status: "released",
+        },
+      ],
+      assignmentMetadata: [],
+    });
+
+    renderExplainGrade();
+
+    expect(await screen.findByText("fallback-report.pdf")).toBeInTheDocument();
+    expect(screen.queryByText(/Sam Student/i)).not.toBeInTheDocument();
+  });
+
+  it("falls back to Released grade when assignment title and file name are unavailable", async () => {
+    setupSupabase({
+      submissions: [
+        {
+          id: "submission-1",
+          assignment_id: "assignment-1",
+          student_name: "Sam Student",
+          file_name: null,
+          status: "released",
+        },
+      ],
+      assignmentMetadata: [],
+    });
+
+    renderExplainGrade();
+
+    expect(await screen.findByText("Released grade")).toBeInTheDocument();
+    expect(screen.queryByText(/Sam Student/i)).not.toBeInTheDocument();
   });
 
   it("shows safe student guidance without exposing provisional or unreleased grading data", async () => {

--- a/src/test/NetworkFailure.test.tsx
+++ b/src/test/NetworkFailure.test.tsx
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   },
   supabase: {
     from: vi.fn(),
+    rpc: vi.fn(),
     auth: {
       getSession: vi.fn(),
     },
@@ -196,6 +197,18 @@ const setupStudentProfileSupabase = () => {
 const setupExplainGradeSupabase = () => {
   mocks.supabase.auth.getSession.mockResolvedValue({
     data: { session: { access_token: "test-token" } },
+  });
+  mocks.supabase.rpc.mockResolvedValue({
+    data: [
+      {
+        assignment_id: "assignment-1",
+        max_score: 100,
+        module_code: "ENG101",
+        submission_id: "submission-1",
+        title: "Critical Essay",
+      },
+    ],
+    error: null,
   });
 
   mocks.supabase.from.mockImplementation((table: string) => ({

--- a/src/test/explainGradeContext.test.ts
+++ b/src/test/explainGradeContext.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import { buildReleasedGradeContext } from "../../supabase/functions/_shared/explain-grade-context";
+
+const makeError = (status: number, message: string) => Object.assign(new Error(message), { status });
+
+const releasedRows = {
+  submission: {
+    id: "6f951f5c-2665-48c8-b404-3ef9b6288882",
+    assignment_id: "985386a6-9981-48eb-8277-568b0ec4957f",
+    student_id: "student-1",
+    file_name: "essay.pdf",
+    status: "released",
+  },
+  grade: {
+    id: "grade-1",
+    submission_id: "6f951f5c-2665-48c8-b404-3ef9b6288882",
+    final_score: 74,
+    ai_feedback: "Released feedback",
+    ai_breakdown: [{ criterion: "Argument", score: 18, max_score: 25 }],
+    grading_confidence: 0.82,
+  },
+  assignment: {
+    id: "985386a6-9981-48eb-8277-568b0ec4957f",
+    module_code: "ENG101",
+    title: "Critical Essay",
+    max_score: 100,
+  },
+};
+
+describe("released explain-grade context", () => {
+  it("allows a student to explain their own released grade", () => {
+    const context = buildReleasedGradeContext(releasedRows, "student-1", makeError);
+
+    expect(context).toMatchObject({
+      submissionId: releasedRows.submission.id,
+      gradeId: "grade-1",
+      assessment: "ENG101 Critical Essay",
+      status: "released",
+      totalGrade: 74,
+      feedback: "Released feedback",
+    });
+  });
+
+  it("rejects unreleased grades without exposing AI feedback", () => {
+    expect(() =>
+      buildReleasedGradeContext(
+        {
+          ...releasedRows,
+          submission: { ...releasedRows.submission, status: "approved" },
+          grade: { ...releasedRows.grade, ai_feedback: "Unreleased private AI feedback" },
+        },
+        "student-1",
+        makeError,
+      ),
+    ).toThrow(/Grade is not released/);
+
+    try {
+      buildReleasedGradeContext(
+        {
+          ...releasedRows,
+          submission: { ...releasedRows.submission, status: "approved" },
+          grade: { ...releasedRows.grade, ai_feedback: "Unreleased private AI feedback" },
+        },
+        "student-1",
+        makeError,
+      );
+    } catch (error) {
+      expect((error as Error).message).not.toMatch(/private AI feedback/i);
+      expect((error as Error & { status: number }).status).toBe(403);
+    }
+  });
+
+  it("rejects another student's grade", () => {
+    try {
+      buildReleasedGradeContext(releasedRows, "student-2", makeError);
+      throw new Error("Expected access check to fail");
+    } catch (error) {
+      expect((error as Error).message).toBe("Forbidden");
+      expect((error as Error & { status: number }).status).toBe(403);
+    }
+  });
+
+  it("uses server-side grade rows instead of fake browser gradeContext", () => {
+    const fakeBrowserGradeContext = {
+      totalGrade: 100,
+      feedback: "Fake browser feedback",
+      breakdown: [{ criterion: "Fake", score: 100, max_score: 100 }],
+    };
+    const context = buildReleasedGradeContext(releasedRows, "student-1", makeError);
+
+    expect(context.totalGrade).toBe(74);
+    expect(context.feedback).toBe("Released feedback");
+    expect(JSON.stringify(context)).not.toContain(fakeBrowserGradeContext.feedback);
+  });
+});

--- a/supabase/functions/_shared/explain-grade-context.ts
+++ b/supabase/functions/_shared/explain-grade-context.ts
@@ -1,0 +1,83 @@
+type SubmissionAccessRow = {
+  id: string;
+  assignment_id: string | null;
+  student_id: string | null;
+  student_name?: string | null;
+  student_email?: string | null;
+  file_name?: string | null;
+  status?: string | null;
+};
+
+type GradeAccessRow = {
+  id: string;
+  submission_id: string;
+  ai_score?: number | null;
+  final_score?: number | null;
+  ai_feedback?: string | null;
+  ai_breakdown?: unknown;
+  grading_confidence?: number | null;
+};
+
+type AssignmentAccessRow = {
+  id: string;
+  title?: string | null;
+  module_code?: string | null;
+  max_score?: number | null;
+};
+
+export type ReleasedGradeContextRows = {
+  submission: SubmissionAccessRow | null;
+  grade: GradeAccessRow | null;
+  assignment?: AssignmentAccessRow | null;
+};
+
+type CreateAccessError = (status: number, message: string) => Error;
+
+const defaultCreateAccessError: CreateAccessError = (status, message) => {
+  const error = new Error(message) as Error & { status: number };
+  error.status = status;
+  return error;
+};
+
+export function buildReleasedGradeContext(
+  rows: ReleasedGradeContextRows,
+  userId: string,
+  createAccessError: CreateAccessError = defaultCreateAccessError,
+) {
+  const { submission, grade, assignment } = rows;
+
+  if (!submission) {
+    throw createAccessError(404, "Submission not found");
+  }
+
+  if (submission.student_id !== userId) {
+    throw createAccessError(403, "Forbidden");
+  }
+
+  if (submission.status !== "released") {
+    throw createAccessError(403, "Grade is not released");
+  }
+
+  if (!grade) {
+    throw createAccessError(404, "Released grade not found");
+  }
+
+  const totalGrade = Number(grade.final_score ?? grade.ai_score);
+  if (!Number.isFinite(totalGrade)) {
+    throw createAccessError(404, "Released grade not found");
+  }
+
+  return {
+    submissionId: submission.id,
+    gradeId: grade.id,
+    assessment: assignment
+      ? `${assignment.module_code || ""} ${assignment.title || ""}`.trim() || submission.file_name || submission.id
+      : submission.file_name || submission.id,
+    status: submission.status,
+    totalGrade,
+    maxScore: assignment?.max_score ?? null,
+    feedback: grade.ai_feedback ?? "",
+    breakdown: Array.isArray(grade.ai_breakdown) ? grade.ai_breakdown : [],
+    gradingConfidence: grade.grading_confidence ?? null,
+  };
+}

--- a/supabase/functions/explain-grade/index.ts
+++ b/supabase/functions/explain-grade/index.ts
@@ -1,14 +1,15 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { z } from "https://esm.sh/zod@3.23.8";
-import { jsonError, requireUser } from "../_shared/auth.ts";
+import { createAdminClient, HttpError, jsonError, requireUser } from "../_shared/auth.ts";
 import { createCorsForbiddenResponse, getCorsHeaders } from "../_shared/cors.ts";
+import { buildReleasedGradeContext } from "../_shared/explain-grade-context.ts";
+import { requirePostMethod } from "../_shared/http.ts";
 import { logError, logWarn } from "../_shared/log.ts";
 import { createChatCompletion, getModel } from "../_shared/openai.ts";
 import { applyRateLimit, createRateLimitResponse } from "../_shared/rate-limit.ts";
 
 const ExplainGradeRequestSchema = z.object({
-  submissionId: z.string().uuid().optional(),
-  submissionIds: z.array(z.string().uuid()).max(50).optional(),
+  submissionId: z.string().uuid(),
   message: z.string().min(1).max(2000),
 });
 
@@ -32,6 +33,8 @@ serve(async (req) => {
   const corsHeaders = getCorsHeaders(req);
   if (!corsHeaders) return createCorsForbiddenResponse();
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  const methodError = requirePostMethod(req, corsHeaders);
+  if (methodError) return methodError;
 
   try {
     const { user } = await requireUser(req);
@@ -52,9 +55,6 @@ serve(async (req) => {
 
     const parsed = ExplainGradeRequestSchema.safeParse({
       submissionId: typeof payload?.submissionId === "string" ? payload.submissionId : undefined,
-      submissionIds: Array.isArray(payload?.submissionIds)
-        ? payload.submissionIds.filter((value): value is string => typeof value === "string")
-        : undefined,
       message: typeof payload?.message === "string" ? payload.message : latestUserMessage?.content,
     });
 
@@ -71,11 +71,49 @@ serve(async (req) => {
       );
     }
 
-    const { submissionId, submissionIds, message } = parsed.data;
+    const { submissionId, message } = parsed.data;
     const messages = rawMessages.length > 0
       ? rawMessages
       : [{ role: "user", content: message } satisfies ExplainGradeMessage];
-    const gradeContext = payload?.gradeContext;
+    const admin = createAdminClient();
+    const { data: submission, error: submissionError } = await admin
+      .from("submissions")
+      .select("id, assignment_id, student_id, student_name, student_email, file_name, status")
+      .eq("id", submissionId)
+      .maybeSingle();
+
+    if (submissionError) {
+      throw new Error("Failed to load submission");
+    }
+
+    const { data: grade, error: gradeError } = await admin
+      .from("grades")
+      .select("id, submission_id, ai_score, final_score, ai_feedback, ai_breakdown, grading_confidence")
+      .eq("submission_id", submissionId)
+      .maybeSingle();
+
+    if (gradeError) {
+      throw new Error("Failed to load released grade");
+    }
+
+    const assignmentId = typeof submission?.assignment_id === "string" ? submission.assignment_id : null;
+    const { data: assignment, error: assignmentError } = assignmentId
+      ? await admin
+          .from("assignments")
+          .select("id, title, module_code, max_score")
+          .eq("id", assignmentId)
+          .maybeSingle()
+      : { data: null, error: null };
+
+    if (assignmentError) {
+      throw new Error("Failed to load assignment context");
+    }
+
+    const gradeContext = buildReleasedGradeContext(
+      { submission, grade, assignment },
+      user.id,
+      (status, errorMessage) => new HttpError(status, errorMessage),
+    );
     const chatModel = getModel("OPENAI_CHAT_MODEL", "gpt-5.4-mini");
 
     const systemPrompt = `You are GradeAI, a supportive academic grade assistant for university students. You use the Socratic method to help students reflect on their work and understand their grades.


### PR DESCRIPTION
## Summary

Phase 2 hardening for the Explain Grade workflow.

- Requires `submissionId` for explain-grade requests
- Loads submission, grade, and assignment context server-side
- Verifies `submission.student_id === user.id`
- Requires the submission to be released before generating explanations
- Ignores browser-supplied `gradeContext`
- Updates the frontend to send `{ submissionId, messages }` instead of full grade context
- Adds a testable shared context builder and tests

## Verification

- `npm run lint` passed
- `npm run test` passed on rerun: 38 files / 156 tests
- `npm run build` passed

Note: the first test run printed all tests passing but exited with a Node/V8 fatal error afterward. The rerun completed cleanly with exit code 0.

## Scope

Only these files are included:
- `src/pages/dashboard/ExplainGrade.tsx`
- `src/test/ExplainGrade.test.tsx`
- `src/test/explainGradeContext.test.ts`
- `supabase/functions/_shared/explain-grade-context.ts`
- `supabase/functions/explain-grade/index.ts`

Subject-aware grading router changes were intentionally not included.