### PR TITLE
Improve Explain Grade percentage-loss weakness reasoning

### DIFF
--- a/src/test/explainGradeContext.test.ts
+++ b/src/test/explainGradeContext.test.ts
@@ -44,6 +44,42 @@ describe("released explain-grade context", () => {
     });
   });
 
+  it("orders criterion insights by percentage lost, not raw points lost", () => {
+    const context = buildReleasedGradeContext(
+      {
+        ...releasedRows,
+        grade: {
+          ...releasedRows.grade,
+          ai_breakdown: [
+            { criterion: "Breadth", score: 21, max_score: 25 },
+            { criterion: "Complexity Analysis", score: 11, max_score: 15 },
+          ],
+        },
+      },
+      "student-1",
+      makeError,
+    );
+
+    expect(context.criterionInsights).toEqual([
+      {
+        criterion: "Complexity Analysis",
+        score: 11,
+        maxScore: 15,
+        earnedPercentage: 73.3,
+        lostPoints: 4,
+        lostPercentage: 26.7,
+      },
+      {
+        criterion: "Breadth",
+        score: 21,
+        maxScore: 25,
+        earnedPercentage: 84,
+        lostPoints: 4,
+        lostPercentage: 16,
+      },
+    ]);
+  });
+
   it("rejects unreleased grades without exposing AI feedback", () => {
     expect(() =>
       buildReleasedGradeContext(

--- a/supabase/functions/_shared/explain-grade-context.ts
+++ b/supabase/functions/_shared/explain-grade-context.ts
@@ -39,6 +39,53 @@ const defaultCreateAccessError: CreateAccessError = (status, message) => {
   return error;
 };
 
+type BreakdownRow = {
+  criterion?: string | null;
+  name?: string | null;
+  score?: number | null;
+  max_score?: number | null;
+  maxScore?: number | null;
+};
+
+function toFiniteNumber(value: unknown) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function buildCriterionInsights(breakdown: unknown) {
+  if (!Array.isArray(breakdown)) return [];
+
+  return breakdown
+    .filter((row): row is BreakdownRow => Boolean(row) && typeof row === "object")
+    .map((row) => {
+      const criterion = typeof row.criterion === "string"
+        ? row.criterion.trim()
+        : typeof row.name === "string"
+          ? row.name.trim()
+          : "";
+      const score = toFiniteNumber(row.score) ?? 0;
+      const maxScore = toFiniteNumber(row.max_score ?? row.maxScore) ?? 0;
+      const earnedPercentage = maxScore > 0 ? Number(((score / maxScore) * 100).toFixed(1)) : 0;
+      const lostPoints = maxScore > 0 ? Number((maxScore - score).toFixed(2)) : 0;
+      const lostPercentage = maxScore > 0 ? Number((((maxScore - score) / maxScore) * 100).toFixed(1)) : 0;
+
+      return {
+        criterion: criterion || "Unknown",
+        score,
+        maxScore,
+        earnedPercentage,
+        lostPoints,
+        lostPercentage,
+      };
+    })
+    .sort((left, right) => {
+      if (right.lostPercentage !== left.lostPercentage) {
+        return right.lostPercentage - left.lostPercentage;
+      }
+      return right.lostPoints - left.lostPoints;
+    });
+}
+
 export function buildReleasedGradeContext(
   rows: ReleasedGradeContextRows,
   userId: string,
@@ -78,6 +125,7 @@ export function buildReleasedGradeContext(
     maxScore: assignment?.max_score ?? null,
     feedback: grade.ai_feedback ?? "",
     breakdown: Array.isArray(grade.ai_breakdown) ? grade.ai_breakdown : [],
+    criterionInsights: buildCriterionInsights(grade.ai_breakdown),
     gradingConfidence: grade.grading_confidence ?? null,
   };
 }

--- a/supabase/functions/explain-grade/index.ts
+++ b/supabase/functions/explain-grade/index.ts
@@ -125,6 +125,8 @@ Guidelines:
 - Use the Socratic method: ask guiding questions instead of giving direct answers
 - Instead of "Your essay lacked structure", ask "What do you think was the strongest part of your argument?"
 - Instead of "You lost marks on testing", ask "How did you decide which test cases to include?"
+- When comparing weaknesses across criteria, use percentage lost within each criterion from criterionInsights, not raw points lost
+- When identifying the weakest area, explicitly mention the percentage loss comparison, for example: "Complexity Analysis is your weakest area, where you lost 26.7% of available marks, compared to 16% in Correct Implementation."
 - Help students discover insights about their work through reflection
 - Reference specific components from their grade breakdown
 - Be encouraging and supportive


### PR DESCRIPTION
## Summary

Follow-up Explain Grade quality improvement after Phase 2.

- Adds percentage-loss criterion insights for explanation support
- Ranks weaknesses by percentage of available marks lost, not raw points lost
- Uses raw lost points only as a tiebreaker
- Updates the Explain Grade prompt so responses explicitly state percentage-loss comparisons when naming weaknesses

Example target behaviour:

- `21/25` = 16% lost
- `11/15` = 26.7% lost
- Complexity Analysis should be identified as the larger weakness for explanation purposes

## Scope

- No scoring logic changes
- No grading calculation changes
- No fairness logic changes
- No review flag changes
- No auth/RLS/security changes
- Explanation quality only

## Verification

- `npm run lint` passed
- `npm run test` passed
- `npm run build` passed

## Changed files

- `supabase/functions/_shared/explain-grade-context.ts`
- `supabase/functions/explain-grade/index.ts`
- `src/test/explainGradeContext.test.ts`