### PR TITLE
Restore shared Edge Function HTTP helper

### DIFF
--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -1,0 +1,15 @@
+export function createMethodNotAllowedResponse(corsHeaders: Record<string, string>) {
+  return new Response(JSON.stringify({ error: "Method not allowed" }), {
+    status: 405,
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "application/json",
+      Allow: "POST, OPTIONS",
+    },
+  });
+}
+
+export function requirePostMethod(req: Request, corsHeaders: Record<string, string>) {
+  if (req.method === "POST") return null;
+  return createMethodNotAllowedResponse(corsHeaders);
+}


### PR DESCRIPTION
## Summary

Restores the missing shared Edge Function HTTP helper required by `explain-grade` deployment.

## Why

`npx supabase functions deploy` failed because `supabase/functions/explain-grade/index.ts` imports `../_shared/http.ts`, but the helper was missing from the branch. Restoring the helper allowed Edge Function deployment to complete successfully.

## Validation

- `npm run test` passed
- `npm run build` passed
- `npx supabase functions deploy` passed

## Notes

Only `supabase/functions/_shared/http.ts` is included in this follow-up change. No environment files or unrelated app files were committed.