### PR TITLE
Harden grading file validation and assignment access checks

### DIFF
--- a/src/pages/dashboard/AssignmentDetail.tsx
+++ b/src/pages/dashboard/AssignmentDetail.tsx
@@ -294,6 +294,11 @@ const buildRecommendedActionLabel = (value?: string) =>
 
 const getErrorMessage = (error: unknown) => (error instanceof Error ? error.message : "AI grading failed");
 
+const hasGradableSubmissionFile = (submission: AssignmentDetailSubmission) => {
+  const candidate = `${submission.file_name ?? ""} ${submission.file_url ?? ""}`.toLowerCase();
+  return Boolean(submission.file_url?.trim()) && (candidate.includes(".pdf") || candidate.includes(".docx") || candidate.includes(".txt"));
+};
+
 const AssignmentDetail = () => {
   const { id } = useParams<{ id: string }>();
   const { role, user, profile, isDemo } = useAuth();
@@ -805,12 +810,32 @@ const AssignmentDetail = () => {
     if (!assignment) return;
 
     setGrading(true);
-    setGradingCount(toGrade.length);
+    if (role === "lecturer" && user?.id && assignment.lecturer_id !== user.id) {
+      toast.error("You can only grade assignments that are assigned to your lecturer account.");
+      return;
+    }
+
+    const preflightFailures = toGrade.filter((submission) => !hasGradableSubmissionFile(submission));
+    const gradableSubmissions = toGrade.filter((submission) => hasGradableSubmissionFile(submission));
+
+    if (preflightFailures.length > 0) {
+      toast.error(
+        preflightFailures.length === toGrade.length
+          ? "Selected submissions are missing a readable PDF, DOCX, or TXT file."
+          : `${preflightFailures.length} submission(s) were skipped because the file is missing or unsupported.`,
+      );
+    }
+
+    if (gradableSubmissions.length === 0) {
+      return;
+    }
+
+    setGradingCount(gradableSubmissions.length);
     setGradingElapsed(0);
     gradingTimerRef.current = setInterval(() => setGradingElapsed((p) => p + 1), 1000);
-    toast.info(`Sending ${toGrade.length} submission(s) for AI grading...`);
+    toast.info(`Sending ${gradableSubmissions.length} submission(s) for AI grading...`);
 
-    for (const sub of toGrade) {
+    for (const sub of gradableSubmissions) {
       try {
         await supabase.from("submissions").update({ status: "ai_grading" as const }).eq("id", sub.id);
       } catch {}
@@ -820,7 +845,7 @@ const AssignmentDetail = () => {
       const { data, error } = await supabase.functions.invoke<GradeSubmissionInvokeData>("grade-submission", {
         body: {
           assignmentId: assignment.id,
-          submissions: toGrade.map((s) => ({ id: s.id })),
+          submissions: gradableSubmissions.map((s) => ({ id: s.id })),
         },
       });
 
@@ -831,7 +856,7 @@ const AssignmentDetail = () => {
       const failureMessages = new Set<string>();
 
       for (const r of results) {
-        const sub = toGrade.find((s) => s.id === r.submissionId);
+        const sub = gradableSubmissions.find((s) => s.id === r.submissionId);
         if (!sub) continue;
 
         if (r.success) {
@@ -902,7 +927,7 @@ const AssignmentDetail = () => {
       }
     } catch (err: unknown) {
       toast.error(getErrorMessage(err));
-      for (const sub of toGrade) {
+      for (const sub of gradableSubmissions) {
         try {
           await supabase.from("submissions").update({ status: sub.status }).eq("id", sub.id);
         } catch {}

--- a/supabase/functions/grade-submission/index.ts
+++ b/supabase/functions/grade-submission/index.ts
@@ -1093,12 +1093,25 @@ async function fetchSubmissionContent(
   supabaseAdmin: ReturnType<typeof createAdminClient>,
   sub: { file_url: string; file_name: string | null },
 ) {
+  const normalizedPath = normalizeSubmissionStoragePath(sub.file_url);
+  if (!normalizedPath) {
+    throw new Error("Submission file URL is missing. Re-upload the document and try again.");
+  }
+
+  if (!isSupportedSubmissionFile(sub.file_name, normalizedPath)) {
+    throw new Error("Submission file type is not supported. Upload a readable PDF, DOCX, or TXT file.");
+  }
+
   const { data: fileData, error: dlError } = await supabaseAdmin.storage
     .from("submissions")
-    .download(sub.file_url);
+    .download(normalizedPath);
 
   if (dlError || !fileData) {
-    throw new Error("Failed to download file");
+    const message = dlError?.message?.toLowerCase() ?? "";
+    if (message.includes("not found") || message.includes("404")) {
+      throw new Error("Submission file could not be found in storage. Re-upload the document and try again.");
+    }
+    throw new Error("Submission file could not be downloaded. Re-upload the document and try again.");
   }
 
   const extraction = await extractSubmissionDocument({
@@ -1125,6 +1138,29 @@ async function fetchSubmissionContent(
       extraction_error: extraction.extractionError,
     },
   };
+}
+
+function normalizeSubmissionStoragePath(fileUrl: string | null | undefined) {
+  const trimmed = typeof fileUrl === "string" ? fileUrl.trim() : "";
+  if (!trimmed) return null;
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return trimmed.replace(/^\/+/, "");
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    const marker = "/submissions/";
+    const markerIndex = parsed.pathname.indexOf(marker);
+    if (markerIndex === -1) return null;
+    return decodeURIComponent(parsed.pathname.slice(markerIndex + marker.length));
+  } catch {
+    return null;
+  }
+}
+
+function isSupportedSubmissionFile(fileName: string | null | undefined, fileUrl: string | null | undefined) {
+  const candidate = `${fileName ?? ""} ${fileUrl ?? ""}`.toLowerCase();
+  return candidate.includes(".pdf") || candidate.includes(".docx") || candidate.includes(".txt");
 }
 
 function buildSystemPrompt(assignmentType: AssignmentType, rubricLength: number, maxScore: number) {
@@ -1392,7 +1428,7 @@ serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
 
   try {
-    const { user } = await requireLecturer(req);
+    const { supabase: userSupabase, user } = await requireLecturer(req);
     const rateLimit = applyRateLimit(req, {
       scope: "grade-submission",
       limit: 5,
@@ -1467,15 +1503,16 @@ serve(async (req) => {
     if (forceRegenerate && !actorIsAdmin) {
       throw new HttpError(403, "Only admins can force AI re-grading");
     }
-    const { data: assignment, error: assignmentError } = await supabaseAdmin
+    const assignmentClient = actorIsAdmin ? supabaseAdmin : userSupabase;
+    const { data: assignment, error: assignmentError } = await assignmentClient
       .from("assignments")
       .select("id, lecturer_id, title, description, module_code, max_score, rubric")
       .eq("id", requestedAssignmentId)
       .maybeSingle();
 
     if (assignmentError) throw new Error("Failed to load assignment");
-    if (!assignment || assignment.lecturer_id !== user.id) {
-      throw new HttpError(403, "You do not have access to this assignment");
+    if (!assignment) {
+      throw new HttpError(403, "You do not have grading access to this assignment.");
     }
 
     const { data: submissions, error: submissionsError } = await supabaseAdmin
@@ -1598,8 +1635,16 @@ serve(async (req) => {
 
     const results: Array<Record<string, unknown>> = [];
     const generatedResultsByFingerprint = new Map<string, CachedGradeResult>();
+    const invalidSubmissionPaths = submissions.filter((sub) => !normalizeSubmissionStoragePath(sub.file_url));
+    for (const sub of invalidSubmissionPaths) {
+      results.push({
+        submissionId: sub.id,
+        error: "Submission file URL is missing. Re-upload the document and try again.",
+        success: false,
+      });
+    }
 
-    for (const sub of submissions) {
+    for (const sub of submissions.filter((item) => normalizeSubmissionStoragePath(item.file_url))) {
       try {
         const existingGrade = existingGradesBySubmission.get(sub.id) ?? null;
         const { extractedText, extractionMetadata } = await fetchSubmissionContent(supabaseAdmin, sub);


### PR DESCRIPTION
## Summary

- Adds preflight validation for missing/unsupported submission files before AI grading
- Normalizes submission storage paths in the grading Edge Function
- Returns clearer errors for missing or unreadable files
- Uses the assignment access model rather than a hard-coded owner-only check

## Validation

- npm run test passed
- npm run build passed

## Notes

This does not change grading prompts, scoring logic, or RLS policies.