### PR TITLE
Update README migration history note

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,7 @@ Current safeguards include:
 
 ## Current State
 
-GradeAI is a working full-stack prototype with several hardened workflows. It is not presented as a finished institution-wide platform. The current focus is making the core assessment, review, moderation, analytics, and support workflows reliable enough for controlled testing and further development.
-The backend is now running against a clean Supabase project with RLS, API grants, storage, Edge Functions, and AI secrets reconfigured under the controlled project setup.
+GradeAI is a working full-stack prototype with several hardened workflows. It is not presented as a finished institution-wide platform. The current focus is making the core assessment, review, moderation, analytics, and support workflows reliable enough for controlled testing and further development. The backend is now running against a clean Supabase project with RLS, API grants, storage, Edge Functions, and AI secrets reconfigured under the controlled project setup.
 
 Working well:
 
@@ -376,13 +375,9 @@ The active deployment target has since been moved to a clean, controlled Supabas
 YYYYMMDDHHMMSS_description.sql
 ```
 
-Do not create new short-form migration IDs such as:
+Do not create new short-form migration IDs.
 
-```text
-YYYYMMDD_description.sql
-```
-
-For deployment setup, environment variables, Supabase secrets, storage, and validation steps, see the [Deployment Guide](docs/DEPLOYMENT_GUIDE.md).
+For deployment setup and environment configuration, see the [Deployment Guide](docs/DEPLOYMENT_GUIDE.md).
 
 ## Deployment Notes
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Current safeguards include:
 ## Current State
 
 GradeAI is a working full-stack prototype with several hardened workflows. It is not presented as a finished institution-wide platform. The current focus is making the core assessment, review, moderation, analytics, and support workflows reliable enough for controlled testing and further development.
+The backend is now running against a clean Supabase project with RLS, API grants, storage, Edge Functions, and AI secrets reconfigured under the controlled project setup.
 
 Working well:
 
@@ -226,6 +227,7 @@ Recent backend and workflow hardening included:
 Supporting documentation:
 
 - [Technical Summary](TECHNICAL_SUMMARY.md)
+- [Deployment Guide](docs/DEPLOYMENT_GUIDE.md)
 - [Security Model](docs/SECURITY_MODEL.md)
 - [Test Coverage Strategy](docs/TEST_COVERAGE_STRATEGY.md)
 - [Rollout Plan](docs/ROLLOUT_PLAN.md)
@@ -366,17 +368,21 @@ Current high-cost Edge Function rate limiting is process-local and in-memory. Th
 
 ## Migration History Note
 
-This project contains two legacy short-form migration versions in Supabase metadata:
+Earlier versions of the project included legacy short-form Supabase migration versions from the Lovable-era setup.
 
-- `20260412`
-- `20260413`
+The active deployment target has since been moved to a clean, controlled Supabase project. New migrations should use full 14-digit timestamp prefixes:
 
-These correspond to:
+```text
+YYYYMMDDHHMMSS_description.sql
+```
 
-- `20260412_fix_multi_tenant_rls.sql`
-- `20260413_create_student_interventions.sql`
+Do not create new short-form migration IDs such as:
 
-Supabase CLI may display these entries as unmatched because of earlier naming inconsistencies in migration IDs. This is a migration ledger hygiene issue, not a schema or permissions failure. Do not rename or modify historical migration IDs on a live project without a deliberate reconciliation plan.
+```text
+YYYYMMDD_description.sql
+```
+
+For deployment setup, environment variables, Supabase secrets, storage, and validation steps, see the [Deployment Guide](docs/DEPLOYMENT_GUIDE.md).
 
 ## Deployment Notes
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,71 @@
+# Deployment Guide
+
+## Supabase setup
+
+This project now uses a clean, controlled Supabase setup.
+
+The old Lovable-era migration history is no longer the active deployment target. The active deployment source is the current canonical migration chain under `supabase/migrations`.
+
+All new migrations must use 14-digit timestamp prefixes in the filename.
+
+Example format:
+
+```text
+YYYYMMDDHHMMSS_description.sql
+```
+
+## Frontend environment variables
+
+Frontend env var names:
+
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_PUBLISHABLE_KEY`
+- `VITE_SUPABASE_ANON_KEY`
+
+## Edge Function secrets
+
+Edge Function secret names:
+
+- `OPENAI_API_KEY`
+- `OPENAI_GRADING_MODEL`
+- `OPENAI_INTEGRITY_MODEL`
+- `OPENAI_CHAT_MODEL`
+- `EMAIL_NOTIFICATIONS_ENABLED`
+- `APP_BASE_URL`
+- `ENV`
+- `RESEND_API_KEY`
+- `EMAIL_FROM_ADDRESS`
+
+## Storage
+
+Private storage bucket name:
+
+- `submissions`
+
+## Deploy commands
+
+Run deployment in this order:
+
+```bash
+npx supabase db push --dry-run --linked --include-all
+npx supabase db push --linked --include-all
+npx supabase functions deploy
+```
+
+## Validation checklist
+
+Run local validation:
+
+```bash
+npm run test
+npm run build
+npm run test:coverage
+```
+
+Then verify:
+
+- login works
+- profile loads
+- upload works
+- AI grading works
+- explain-grade works


### PR DESCRIPTION
Updates the README to reflect the clean Supabase deployment setup and the current migration history note.

Includes:
- deployment guide link in documentation
- updated migration history wording for the controlled Supabase project
- current state note about the clean backend project setup