### PR TITLE
Add internal text similarity integrity provider foundation

### DIFF
--- a/supabase/functions/_shared/integrity-provider.ts
+++ b/supabase/functions/_shared/integrity-provider.ts
@@ -1,0 +1,61 @@
+export type IntegrityProviderName =
+  | "internal_text_similarity"
+  | "llm_legacy"
+  | "moss"
+  | "external_provider";
+
+export type IntegritySeverity = "low" | "medium" | "high";
+
+export type IntegrityProviderFinding = {
+  provider: IntegrityProviderName;
+  assignment_id: string;
+  submission_id: string;
+  compared_submission_id?: string | null;
+  similarity_score: number;
+  severity: IntegritySeverity;
+  evidence_summary: string;
+  matched_phrases: string[];
+  raw_metadata: Record<string, unknown>;
+  analysis_limited: boolean;
+};
+
+export type IntegrityProviderInput = {
+  assignmentId: string;
+  submissionId: string;
+  submissionText: string;
+  comparedSubmissionId?: string | null;
+  comparedText?: string | null;
+  providerMetadata?: Record<string, unknown>;
+};
+
+export function mapSimilarityScoreToSeverity(similarityScore: number): IntegritySeverity {
+  if (similarityScore >= 80) return "high";
+  if (similarityScore >= 50) return "medium";
+  return "low";
+}
+
+export function createAnalysisLimitedFinding(params: {
+  provider: IntegrityProviderName;
+  assignmentId: string;
+  submissionId: string;
+  comparedSubmissionId?: string | null;
+  evidenceSummary: string;
+  similarityScore?: number;
+  matchedPhrases?: string[];
+  rawMetadata?: Record<string, unknown>;
+}): IntegrityProviderFinding {
+  const similarityScore = Number.isFinite(params.similarityScore) ? Number(params.similarityScore) : 0;
+
+  return {
+    provider: params.provider,
+    assignment_id: params.assignmentId,
+    submission_id: params.submissionId,
+    compared_submission_id: params.comparedSubmissionId ?? null,
+    similarity_score: similarityScore,
+    severity: mapSimilarityScoreToSeverity(similarityScore),
+    evidence_summary: params.evidenceSummary,
+    matched_phrases: params.matchedPhrases ?? [],
+    raw_metadata: params.rawMetadata ?? {},
+    analysis_limited: true,
+  };
+}

--- a/supabase/functions/_shared/providers/internal-text-similarity.ts
+++ b/supabase/functions/_shared/providers/internal-text-similarity.ts
@@ -1,0 +1,122 @@
+import {
+  createAnalysisLimitedFinding,
+  mapSimilarityScoreToSeverity,
+  type IntegrityProviderFinding,
+} from "../integrity-provider.ts";
+
+const DEFAULT_SHINGLE_SIZE = 8;
+const MIN_WORD_COUNT = 50;
+const MAX_MATCHED_PHRASES = 5;
+
+function tokenizeText(text: string) {
+  return normalizeText(text)
+    .split(" ")
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+function truncatePhrase(phrase: string, maxLength = 140) {
+  if (phrase.length <= maxLength) return phrase;
+  return `${phrase.slice(0, maxLength - 3)}...`;
+}
+
+export function normalizeText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function createWordShingles(text: string, k = DEFAULT_SHINGLE_SIZE): Set<string> {
+  const tokens = tokenizeText(text);
+  if (tokens.length === 0) return new Set<string>();
+  if (tokens.length < k) return new Set<string>([tokens.join(" ")]);
+
+  const shingles = new Set<string>();
+  for (let index = 0; index <= tokens.length - k; index += 1) {
+    shingles.add(tokens.slice(index, index + k).join(" "));
+  }
+
+  return shingles;
+}
+
+export function calculateJaccardSimilarity(shinglesA: Set<string>, shinglesB: Set<string>): number {
+  if (shinglesA.size === 0 || shinglesB.size === 0) return 0;
+
+  let intersectionCount = 0;
+  for (const shingle of shinglesA) {
+    if (shinglesB.has(shingle)) intersectionCount += 1;
+  }
+
+  const unionCount = shinglesA.size + shinglesB.size - intersectionCount;
+  if (unionCount === 0) return 0;
+
+  return intersectionCount / unionCount;
+}
+
+export function analyzeTextSimilarity(
+  submissionText: string,
+  comparedText: string,
+  submissionId: string,
+  comparedId: string,
+  assignmentId = "",
+): IntegrityProviderFinding {
+  const sourceWords = tokenizeText(submissionText);
+  const comparedWords = tokenizeText(comparedText);
+
+  if (sourceWords.length < MIN_WORD_COUNT || comparedWords.length < MIN_WORD_COUNT) {
+    return createAnalysisLimitedFinding({
+      provider: "internal_text_similarity",
+      assignmentId,
+      submissionId,
+      comparedSubmissionId: comparedId,
+      evidenceSummary:
+        "Internal text similarity analysis was limited because one or both submissions were too short for a reliable comparison.",
+      rawMetadata: {
+        reason: "text_too_short",
+        minimum_word_count: MIN_WORD_COUNT,
+        submission_word_count: sourceWords.length,
+        compared_word_count: comparedWords.length,
+      },
+    });
+  }
+
+  const sourceShingles = createWordShingles(submissionText);
+  const comparedShingles = createWordShingles(comparedText);
+  const similarityRatio = calculateJaccardSimilarity(sourceShingles, comparedShingles);
+  const similarityScore = Math.round(similarityRatio * 100);
+
+  const allMatches = [...sourceShingles].filter((shingle) => comparedShingles.has(shingle));
+  const matchedPhrases = allMatches
+    .slice(0, MAX_MATCHED_PHRASES)
+    .map((phrase) => truncatePhrase(phrase));
+
+  const evidenceSummary =
+    similarityScore === 0
+      ? "Internal text similarity found no meaningful shared phrasing between these submissions."
+      : `Internal cohort similarity analysis found approximately ${similarityScore}% overlap in repeated word-pattern shingles. This is evidence for lecturer review, not a determination of misconduct.`;
+
+  return {
+    provider: "internal_text_similarity",
+    assignment_id: assignmentId,
+    submission_id: submissionId,
+    compared_submission_id: comparedId,
+    similarity_score: similarityScore,
+    severity: mapSimilarityScoreToSeverity(similarityScore),
+    evidence_summary: evidenceSummary,
+    matched_phrases: matchedPhrases,
+    raw_metadata: {
+      method: "jaccard_word_shingles",
+      shingle_size: DEFAULT_SHINGLE_SIZE,
+      submission_word_count: sourceWords.length,
+      compared_word_count: comparedWords.length,
+      submission_shingle_count: sourceShingles.size,
+      compared_shingle_count: comparedShingles.size,
+      matched_shingle_count: allMatches.length,
+      displayed_matched_phrase_count: matchedPhrases.length,
+      compared_within_assignment_only: true,
+    },
+    analysis_limited: false,
+  };
+}

--- a/supabase/functions/check-plagiarism/index.ts
+++ b/supabase/functions/check-plagiarism/index.ts
@@ -19,6 +19,8 @@ import {
   type StoredWritingProfile,
   type WritingProfileMetrics,
 } from "../_shared/text-analysis.ts";
+import { analyzeTextSimilarity } from "../_shared/providers/internal-text-similarity.ts";
+import type { IntegrityProviderFinding } from "../_shared/integrity-provider.ts";
 
 const CheckPlagiarismRequestSchema = z
   .object({
@@ -36,6 +38,9 @@ const MAX_SINGLE_TEXT_CHARS = 12000;
 const MAX_MULTI_TEXT_CHARS = 3500;
 const OPENAI_RETRY_ATTEMPTS = 2;
 const MIN_INTEGRITY_FLAG_SCORE = 25;
+const INTERNAL_SIMILARITY_MIN_WORDS = 50;
+
+type IntegrityProviderMode = "llm_legacy" | "internal_text_similarity" | "both";
 
 type IntegrityType = "similarity" | "ai-writing" | "baseline-deviation" | "mixed";
 
@@ -100,6 +105,19 @@ type ProcessedSubmissionText = {
   };
 };
 
+type IntegrityFindingInsert = {
+  provider: string;
+  assignment_id: string;
+  submission_id: string;
+  compared_submission_id: string | null;
+  similarity_score: number;
+  severity: string;
+  evidence_summary: string;
+  matched_phrases: string[];
+  raw_metadata: Record<string, unknown>;
+  analysis_limited: boolean;
+};
+
 function clampScore(value: unknown) {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return 0;
@@ -136,6 +154,44 @@ const ASCII_QUOTED_BLOCK_PATTERN = /"[^"]{20,}"/g;
 
 function collapseWhitespace(value: string) {
   return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function countWords(value: string) {
+  return value.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function resolveIntegrityProviderMode(rawBody: Record<string, unknown> | null): IntegrityProviderMode {
+  const envProvider = Deno.env.get("INTEGRITY_PROVIDER_MODE")?.trim().toLowerCase() || "";
+  if (envProvider === "llm_legacy" || envProvider === "internal_text_similarity" || envProvider === "both") {
+    return envProvider;
+  }
+  return "both";
+}
+
+function supportsInternalTextSimilarity(content: {
+  plainText: string;
+  fileType: string;
+  success: boolean;
+  extractionError: string | null;
+}) {
+  if (!content.success || content.extractionError) return false;
+  if (!["pdf", "docx", "txt"].includes(content.fileType)) return false;
+  return countWords(content.plainText) >= INTERNAL_SIMILARITY_MIN_WORDS;
+}
+
+function buildIntegrityFindingInsert(finding: IntegrityProviderFinding): IntegrityFindingInsert {
+  return {
+    provider: finding.provider,
+    assignment_id: finding.assignment_id,
+    submission_id: finding.submission_id,
+    compared_submission_id: finding.compared_submission_id ?? null,
+    similarity_score: finding.similarity_score,
+    severity: finding.severity,
+    evidence_summary: finding.evidence_summary,
+    matched_phrases: finding.matched_phrases,
+    raw_metadata: finding.raw_metadata,
+    analysis_limited: finding.analysis_limited,
+  };
 }
 
 function countCitationPatterns(text: string) {
@@ -772,6 +828,7 @@ serve(async (req) => {
     }
 
     const integrityModel = getModel("OPENAI_INTEGRITY_MODEL", "gpt-5.4-mini");
+    const providerMode = resolveIntegrityProviderMode(rawBody);
     const requestedAssignmentId = parsedRequest.data.assignmentId ?? null;
     const requestedSubmissionIds = parsedRequest.data.submissionIds ?? (parsedRequest.data.submissionId ? [parsedRequest.data.submissionId] : []);
 
@@ -989,161 +1046,204 @@ Only flag real concerns. Return valid JSON only.`,
 
     let parsedFlags: IntegrityFlag[] = [];
     let summary = "Analysis complete";
-    try {
-      const aiData = await createIntegrityResponseWithRetry({
-        model: integrityModel,
-        input: [
-          { role: "developer", content: [{ type: "input_text", text: systemPrompt }] },
-          { role: "user", content: userContent },
-        ],
-        text: {
-          format: {
-            type: "json_schema",
-            name: "report_integrity_results",
-            schema: {
-              type: "object",
-              properties: {
-                flags: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      student_a: { type: "string" },
-                      student_b: { type: "string" },
-                      submission_a_id: { type: "string" },
-                      submission_b_id: { type: "string" },
-                      similarity_score: { type: "number" },
-                      ai_suspicion_score: { type: "number" },
-                      baseline_deviation_score: { type: "number" },
-                      total_risk_score: { type: "number" },
-                      reason: { type: "string" },
-                      evidence_summary: { type: "string" },
-                      matched_excerpt: { type: "string" },
-                      recommended_action: { type: "string", enum: ["clear", "review", "investigate"] },
-                      integrity_type: {
-                        type: "string",
-                        enum: ["similarity", "ai-writing", "baseline-deviation", "mixed"],
-                      },
-                      severity: { type: "string", enum: ["low", "medium", "high"] },
-                      overlap_analysis: {
-                        type: "object",
-                        properties: {
-                          total_overlap: { type: "number" },
-                          cited_overlap: { type: "number" },
-                          uncited_overlap: { type: "number" },
-                          internal_peer_overlap: { type: "number" },
-                          external_source_overlap: { type: "number" },
-                        },
-                        required: [
-                          "total_overlap",
-                          "cited_overlap",
-                          "uncited_overlap",
-                          "internal_peer_overlap",
-                          "external_source_overlap",
-                        ],
-                        additionalProperties: false,
-                      },
-                      evidence_groups: {
-                        type: "object",
-                        properties: {
-                          uncited_matches: {
-                            type: "array",
-                            items: {
-                              type: "object",
-                              properties: {
-                                label: { type: "string" },
-                                value: { type: "string" },
-                                score: { type: "number" },
-                              },
-                              required: ["label", "value", "score"],
-                              additionalProperties: false,
-                            },
-                          },
-                          cited_matches: {
-                            type: "array",
-                            items: {
-                              type: "object",
-                              properties: {
-                                label: { type: "string" },
-                                value: { type: "string" },
-                                score: { type: "number" },
-                              },
-                              required: ["label", "value", "score"],
-                              additionalProperties: false,
-                            },
-                          },
-                          peer_matches: {
-                            type: "array",
-                            items: {
-                              type: "object",
-                              properties: {
-                                label: { type: "string" },
-                                value: { type: "string" },
-                                score: { type: "number" },
-                              },
-                              required: ["label", "value", "score"],
-                              additionalProperties: false,
-                            },
-                          },
-                          external_matches: {
-                            type: "array",
-                            items: {
-                              type: "object",
-                              properties: {
-                                label: { type: "string" },
-                                value: { type: "string" },
-                                score: { type: "number" },
-                              },
-                              required: ["label", "value", "score"],
-                              additionalProperties: false,
-                            },
-                          },
-                        },
-                        required: ["uncited_matches", "cited_matches", "peer_matches", "external_matches"],
-                        additionalProperties: false,
-                      },
-                    },
-                    required: [
-                      "student_a",
-                      "student_b",
-                      "submission_a_id",
-                      "submission_b_id",
-                      "similarity_score",
-                      "ai_suspicion_score",
-                      "baseline_deviation_score",
-                      "total_risk_score",
-                      "reason",
-                      "evidence_summary",
-                      "matched_excerpt",
-                      "recommended_action",
-                      "integrity_type",
-                      "severity",
-                      "overlap_analysis",
-                      "evidence_groups",
-                    ],
-                    additionalProperties: false,
-                  },
-                },
-                summary: { type: "string" },
-              },
-              required: ["flags", "summary"],
-              additionalProperties: false,
-            },
-            strict: true,
-          },
-        },
-      });
+    const shouldRunLegacy = providerMode === "llm_legacy" || providerMode === "both";
+    const shouldRunInternalProvider = providerMode === "internal_text_similarity" || providerMode === "both";
 
+    if (shouldRunLegacy) {
       try {
-        const parsed = parseJsonText(extractOutputText(aiData));
-        parsedFlags = normalizeFlags(parsed?.flags, submissions, processedContentMap);
-        summary = typeof parsed?.summary === "string" && parsed.summary.trim() ? parsed.summary.trim() : summary;
-      } catch {
-        parsedFlags = normalizeFlags(aiData?.output?.[0]?.content?.[0]?.json?.flags, submissions, processedContentMap);
+        const aiData = await createIntegrityResponseWithRetry({
+          model: integrityModel,
+          input: [
+            { role: "developer", content: [{ type: "input_text", text: systemPrompt }] },
+            { role: "user", content: userContent },
+          ],
+          text: {
+            format: {
+              type: "json_schema",
+              name: "report_integrity_results",
+              schema: {
+                type: "object",
+                properties: {
+                  flags: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        student_a: { type: "string" },
+                        student_b: { type: "string" },
+                        submission_a_id: { type: "string" },
+                        submission_b_id: { type: "string" },
+                        similarity_score: { type: "number" },
+                        ai_suspicion_score: { type: "number" },
+                        baseline_deviation_score: { type: "number" },
+                        total_risk_score: { type: "number" },
+                        reason: { type: "string" },
+                        evidence_summary: { type: "string" },
+                        matched_excerpt: { type: "string" },
+                        recommended_action: { type: "string", enum: ["clear", "review", "investigate"] },
+                        integrity_type: {
+                          type: "string",
+                          enum: ["similarity", "ai-writing", "baseline-deviation", "mixed"],
+                        },
+                        severity: { type: "string", enum: ["low", "medium", "high"] },
+                        overlap_analysis: {
+                          type: "object",
+                          properties: {
+                            total_overlap: { type: "number" },
+                            cited_overlap: { type: "number" },
+                            uncited_overlap: { type: "number" },
+                            internal_peer_overlap: { type: "number" },
+                            external_source_overlap: { type: "number" },
+                          },
+                          required: [
+                            "total_overlap",
+                            "cited_overlap",
+                            "uncited_overlap",
+                            "internal_peer_overlap",
+                            "external_source_overlap",
+                          ],
+                          additionalProperties: false,
+                        },
+                        evidence_groups: {
+                          type: "object",
+                          properties: {
+                            uncited_matches: {
+                              type: "array",
+                              items: {
+                                type: "object",
+                                properties: {
+                                  label: { type: "string" },
+                                  value: { type: "string" },
+                                  score: { type: "number" },
+                                },
+                                required: ["label", "value", "score"],
+                                additionalProperties: false,
+                              },
+                            },
+                            cited_matches: {
+                              type: "array",
+                              items: {
+                                type: "object",
+                                properties: {
+                                  label: { type: "string" },
+                                  value: { type: "string" },
+                                  score: { type: "number" },
+                                },
+                                required: ["label", "value", "score"],
+                                additionalProperties: false,
+                              },
+                            },
+                            peer_matches: {
+                              type: "array",
+                              items: {
+                                type: "object",
+                                properties: {
+                                  label: { type: "string" },
+                                  value: { type: "string" },
+                                  score: { type: "number" },
+                                },
+                                required: ["label", "value", "score"],
+                                additionalProperties: false,
+                              },
+                            },
+                            external_matches: {
+                              type: "array",
+                              items: {
+                                type: "object",
+                                properties: {
+                                  label: { type: "string" },
+                                  value: { type: "string" },
+                                  score: { type: "number" },
+                                },
+                                required: ["label", "value", "score"],
+                                additionalProperties: false,
+                              },
+                            },
+                          },
+                          required: ["uncited_matches", "cited_matches", "peer_matches", "external_matches"],
+                          additionalProperties: false,
+                        },
+                      },
+                      required: [
+                        "student_a",
+                        "student_b",
+                        "submission_a_id",
+                        "submission_b_id",
+                        "similarity_score",
+                        "ai_suspicion_score",
+                        "baseline_deviation_score",
+                        "total_risk_score",
+                        "reason",
+                        "evidence_summary",
+                        "matched_excerpt",
+                        "recommended_action",
+                        "integrity_type",
+                        "severity",
+                        "overlap_analysis",
+                        "evidence_groups",
+                      ],
+                      additionalProperties: false,
+                    },
+                  },
+                  summary: { type: "string" },
+                },
+                required: ["flags", "summary"],
+                additionalProperties: false,
+              },
+              strict: true,
+            },
+          },
+        });
+
+        try {
+          const parsed = parseJsonText(extractOutputText(aiData));
+          parsedFlags = normalizeFlags(parsed?.flags, submissions, processedContentMap);
+          summary = typeof parsed?.summary === "string" && parsed.summary.trim() ? parsed.summary.trim() : summary;
+        } catch {
+          parsedFlags = normalizeFlags(aiData?.output?.[0]?.content?.[0]?.json?.flags, submissions, processedContentMap);
+        }
+      } catch (aiError) {
+        warnings.push("AI similarity analysis was temporarily unavailable; returning baseline and persistence-safe results only.");
+        logError("check-plagiarism AI analysis failed after retries", aiError);
       }
-    } catch (aiError) {
-      warnings.push("AI similarity analysis was temporarily unavailable; returning baseline and persistence-safe results only.");
-      logError("check-plagiarism AI analysis failed after retries", aiError);
+    }
+
+    const internalFindings: IntegrityProviderFinding[] = [];
+    if (shouldRunInternalProvider && submissions.length > 1) {
+      const comparableSubmissions = submissions
+        .map((submission) => {
+          const content = contentMap.get(submission.id);
+          if (!content) return null;
+          return supportsInternalTextSimilarity(content)
+            ? {
+              submission,
+              content,
+            }
+            : null;
+        })
+        .filter(
+          (
+            item,
+          ): item is {
+            submission: SubmissionRow;
+            content: Awaited<ReturnType<typeof fetchFileContent>>;
+          } => Boolean(item),
+        );
+
+      for (let leftIndex = 0; leftIndex < comparableSubmissions.length; leftIndex += 1) {
+        for (let rightIndex = leftIndex + 1; rightIndex < comparableSubmissions.length; rightIndex += 1) {
+          const left = comparableSubmissions[leftIndex];
+          const right = comparableSubmissions[rightIndex];
+          const pairwiseFinding = analyzeTextSimilarity(
+            left.content.plainText,
+            right.content.plainText,
+            left.submission.id,
+            right.submission.id,
+            requestedAssignmentId,
+          );
+          internalFindings.push(pairwiseFinding);
+        }
+      }
     }
 
     const similarityBySubmission = new Map<string, number>();
@@ -1450,6 +1550,42 @@ Only flag real concerns. Return valid JSON only.`,
     const existingReviewMap = new Map(
       ((existingReviews || []) as Array<Record<string, unknown>>).map((review) => [String(review.submission_id), review]),
     );
+
+    if (internalFindings.length > 0) {
+      const submissionIds = submissions.map((submission) => submission.id);
+      const { error: deleteFindingsError } = await supabaseAdmin
+        .from("integrity_findings")
+        .delete()
+        .eq("assignment_id", requestedAssignmentId)
+        .eq("provider", "internal_text_similarity")
+        .in("submission_id", submissionIds);
+
+      if (deleteFindingsError && !isRecoverablePersistenceError(deleteFindingsError)) {
+        throw deleteFindingsError;
+      }
+      if (deleteFindingsError) {
+        logWarn("Failed to clear prior internal integrity findings, continuing with insert attempt", {
+          function: "check-plagiarism",
+          assignmentId: requestedAssignmentId,
+        });
+      }
+
+      const findingInserts = internalFindings.map(buildIntegrityFindingInsert);
+      const { error: findingsInsertError } = await supabaseAdmin
+        .from("integrity_findings")
+        .insert(findingInserts);
+
+      if (findingsInsertError && !isRecoverablePersistenceError(findingsInsertError)) {
+        throw findingsInsertError;
+      }
+      if (findingsInsertError) {
+        logWarn("Failed to persist internal integrity findings, continuing without evidence-table persistence", {
+          function: "check-plagiarism",
+          assignmentId: requestedAssignmentId,
+          findingCount: findingInserts.length,
+        });
+      }
+    }
 
     const reviewUpserts = submissions
       .map((submission) => {

--- a/supabase/migrations/20260501170444_add_integrity_findings_table.sql
+++ b/supabase/migrations/20260501170444_add_integrity_findings_table.sql
@@ -1,0 +1,71 @@
+create table if not exists public.integrity_findings (
+  id uuid primary key default gen_random_uuid(),
+  provider text not null check (
+    provider in ('internal_text_similarity', 'llm_legacy', 'moss', 'external_provider')
+  ),
+  assignment_id uuid not null references public.assignments(id) on delete cascade,
+  submission_id uuid not null references public.submissions(id) on delete cascade,
+  compared_submission_id uuid null references public.submissions(id) on delete set null,
+  similarity_score numeric(5,2) not null default 0 check (similarity_score >= 0 and similarity_score <= 100),
+  severity text not null check (severity in ('low', 'medium', 'high')),
+  evidence_summary text not null,
+  matched_phrases jsonb not null default '[]'::jsonb,
+  raw_metadata jsonb not null default '{}'::jsonb,
+  analysis_limited boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_integrity_findings_assignment_id
+  on public.integrity_findings (assignment_id);
+
+create index if not exists idx_integrity_findings_submission_id
+  on public.integrity_findings (submission_id);
+
+create index if not exists idx_integrity_findings_provider
+  on public.integrity_findings (provider);
+
+create index if not exists idx_integrity_findings_created_at
+  on public.integrity_findings (created_at desc);
+
+alter table public.integrity_findings enable row level security;
+
+grant select on public.integrity_findings to authenticated;
+grant insert on public.integrity_findings to service_role;
+
+create policy "Authenticated users cannot insert integrity findings"
+on public.integrity_findings
+for insert
+to authenticated
+with check (false);
+
+create policy "Lecturers can view integrity findings for own assignments"
+on public.integrity_findings
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.assignments a
+    where a.id = integrity_findings.assignment_id
+      and a.lecturer_id = auth.uid()
+  )
+);
+
+create policy "Admins can view all integrity findings"
+on public.integrity_findings
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.user_roles ur
+    where ur.user_id = auth.uid()
+      and ur.role = 'admin'
+  )
+  or exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role = 'admin'
+  )
+);


### PR DESCRIPTION
## Summary

Adds the Phase 1 internal integrity-provider foundation and integrates internal text similarity into `check-plagiarism` without removing the legacy LLM flow.

## Included

- shared integrity provider types
- internal text similarity provider using cohort pairwise shingle comparison
- `integrity_findings` evidence table with RLS
- explicit policy denying authenticated browser inserts
- `check-plagiarism` provider routing controlled by `INTEGRITY_PROVIDER_MODE`
- internal text similarity persistence to `integrity_findings`
- legacy response shape preserved for the current frontend

## Safety

- does not remove or significantly refactor the existing `llm_legacy` path
- does not change frontend pages or UI behavior
- keeps lecturer review as the final decision maker
- stores new findings as evidence only
- provider mode is env-controlled only; request bodies cannot disable the legacy path

## Validation

- `npm run test` passed
- `npm run build` passed