### PR TITLE
Unify student grade projection and explain-grade released context

### DIFF
--- a/src/test/explainGradeContext.test.ts
+++ b/src/test/explainGradeContext.test.ts
@@ -48,6 +48,13 @@ describe("released explain-grade context", () => {
       totalGrade: 74,
       feedback: "Released feedback",
     });
+    expect(context.evidenceSummary).toMatchObject({
+      evidenceQuality: "moderate",
+      criterionCount: 1,
+      hasStructuredBreakdown: true,
+      hasFeedback: true,
+      gradingConfidence: 0.82,
+    });
   });
 
   it("orders criterion insights by percentage lost, not raw points lost", () => {
@@ -160,11 +167,41 @@ describe("released explain-grade context", () => {
     expect(prompt).toContain("Complexity Analysis.");
     expect(prompt).toContain("Do not recompute the weakest criterion.");
     expect(prompt).toContain(buildWeaknessIntentInstruction());
+    expect(prompt).toContain("Treat the structured released grade context as the source of truth.");
+    expect(prompt).toContain("Evidence guidance:");
     expect(prompt).toContain(
       "Complexity Analysis is the weakest criterion. The student scored 11/15, meaning they lost 26.7% of available marks. This is higher than the loss in Correct Implementation, where they lost 16%.",
     );
     expect(prompt).toContain("Do not use raw mark loss.");
     expect(prompt).not.toContain("Always use raw marks");
+  });
+
+  it("marks evidence quality as limited when released evidence is sparse", () => {
+    const context = buildReleasedGradeContext(
+      {
+        ...releasedRows,
+        grade: {
+          ...releasedRows.grade,
+          ai_feedback: "",
+          ai_breakdown: [],
+          grading_confidence: 0.55,
+        },
+      },
+      "student-1",
+      makeError,
+    );
+    const prompt = buildExplainGradeSystemPrompt(context, "Why did I get this mark?");
+
+    expect(context.evidenceSummary).toMatchObject({
+      evidenceQuality: "limited",
+      criterionCount: 0,
+      hasStructuredBreakdown: false,
+      hasFeedback: false,
+      gradingConfidence: 0.55,
+    });
+    expect(context.evidenceSummary.evidenceWarnings).toContain("No structured criterion breakdown is available.");
+    expect(prompt).toContain("Evidence quality is limited. Do not guess.");
+    expect(prompt).toContain("If a detail is missing from the released context, say it is unavailable instead of inferring it.");
   });
 
   it("detects weakness-ranking intent phrases", () => {

--- a/supabase/functions/_shared/explain-grade-context.ts
+++ b/supabase/functions/_shared/explain-grade-context.ts
@@ -57,6 +57,17 @@ export type CriterionInsight = {
   lostPercentage: number;
 };
 
+export type EvidenceQuality = "strong" | "moderate" | "limited";
+
+export type ExplainGradeEvidenceSummary = {
+  evidenceQuality: EvidenceQuality;
+  criterionCount: number;
+  hasStructuredBreakdown: boolean;
+  hasFeedback: boolean;
+  gradingConfidence: number | null;
+  evidenceWarnings: string[];
+};
+
 function toFiniteNumber(value: unknown) {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : null;
@@ -111,6 +122,48 @@ export function buildWeaknessGuidance(
   return `${weakestCriterion.name} is the weakest criterion. The student scored ${weakestCriterion.score}/${weakestCriterion.maxScore}, meaning they lost ${weakestCriterion.lostPercentage}% of available marks.${comparisonSentence}`;
 }
 
+export function buildExplainGradeEvidenceSummary({
+  criterionInsights,
+  feedback,
+  gradingConfidence,
+}: {
+  criterionInsights: CriterionInsight[];
+  feedback: string;
+  gradingConfidence: number | null;
+}): ExplainGradeEvidenceSummary {
+  const hasStructuredBreakdown = criterionInsights.length > 0;
+  const hasFeedback = feedback.trim().length > 0;
+  const evidenceWarnings: string[] = [];
+
+  if (!hasStructuredBreakdown) {
+    evidenceWarnings.push("No structured criterion breakdown is available.");
+  }
+
+  if (!hasFeedback) {
+    evidenceWarnings.push("No released narrative feedback is available.");
+  }
+
+  if (gradingConfidence != null && gradingConfidence < 0.7) {
+    evidenceWarnings.push("Grading confidence is below the normal confidence threshold.");
+  }
+
+  let evidenceQuality: EvidenceQuality = "strong";
+  if (!hasStructuredBreakdown || (!hasFeedback && criterionInsights.length < 2)) {
+    evidenceQuality = "limited";
+  } else if (!hasFeedback || criterionInsights.length < 2 || (gradingConfidence != null && gradingConfidence < 0.7)) {
+    evidenceQuality = "moderate";
+  }
+
+  return {
+    evidenceQuality,
+    criterionCount: criterionInsights.length,
+    hasStructuredBreakdown,
+    hasFeedback,
+    gradingConfidence,
+    evidenceWarnings,
+  };
+}
+
 export function buildReleasedGradeContext(
   rows: ReleasedGradeContextRows,
   userId: string,
@@ -139,6 +192,12 @@ export function buildReleasedGradeContext(
     throw createAccessError(404, "Released grade not found");
   }
   const criterionInsights = buildCriterionInsights(grade.ai_breakdown);
+  const feedback = grade.ai_feedback ?? "";
+  const evidenceSummary = buildExplainGradeEvidenceSummary({
+    criterionInsights,
+    feedback,
+    gradingConfidence: grade.grading_confidence ?? null,
+  });
 
   return {
     submissionId: submission.id,
@@ -149,10 +208,11 @@ export function buildReleasedGradeContext(
     status: submission.status,
     totalGrade,
     maxScore: assignment?.max_score ?? null,
-    feedback: grade.ai_feedback ?? "",
+    feedback,
     breakdown: Array.isArray(grade.ai_breakdown) ? grade.ai_breakdown : [],
     criterionInsights,
     weakestCriterion: criterionInsights[0] ?? null,
     gradingConfidence: grade.grading_confidence ?? null,
+    evidenceSummary,
   };
 }

--- a/supabase/functions/_shared/explain-grade-prompt.ts
+++ b/supabase/functions/_shared/explain-grade-prompt.ts
@@ -1,4 +1,4 @@
-import type { CriterionInsight } from "./explain-grade-context.ts";
+import type { CriterionInsight, ExplainGradeEvidenceSummary } from "./explain-grade-context.ts";
 import { buildWeaknessGuidance } from "./explain-grade-context.ts";
 
 const WEAKNESS_INTENT_PATTERNS = [
@@ -13,6 +13,7 @@ const WEAKNESS_INTENT_PATTERNS = [
 type ExplainGradeContext = {
   weakestCriterion: CriterionInsight | null;
   criterionInsights: CriterionInsight[];
+  evidenceSummary: ExplainGradeEvidenceSummary;
 };
 
 export function hasWeaknessIntent(message: string) {
@@ -22,6 +23,18 @@ export function hasWeaknessIntent(message: string) {
 
 export function buildWeaknessIntentInstruction() {
   return "The student is asking for weakness ranking. Answer using weakestCriterion only. Do not use raw mark loss.";
+}
+
+function buildEvidenceGuardrail(evidenceSummary: ExplainGradeEvidenceSummary) {
+  if (evidenceSummary.evidenceQuality === "strong") {
+    return "Evidence quality is strong. You may explain the released grade confidently, but only using facts present in the released context.";
+  }
+
+  if (evidenceSummary.evidenceQuality === "moderate") {
+    return "Evidence quality is moderate. Stay close to explicit released facts and avoid over-specific claims that are not directly supported.";
+  }
+
+  return "Evidence quality is limited. Do not guess. If the released context does not support a specific claim, say that the detail is unavailable from the released evidence.";
 }
 
 export function buildWeaknessRankingResponse(
@@ -55,6 +68,7 @@ This is based on the highest percentage of available marks lost, not raw marks l
 Weakness guidance:
 ${weaknessGuidance}`
     : "";
+  const evidenceGuardrail = buildEvidenceGuardrail(gradeContext.evidenceSummary);
 
   return `You are GradeAI, a supportive academic grade assistant for university students. You use the Socratic method to help students reflect on their work and understand their grades.
 
@@ -67,7 +81,19 @@ ${weakestCriterionFact}
 Weakness guidance:
 ${weaknessGuidance}
 
+Evidence guidance:
+${evidenceGuardrail}
+
+Evidence summary:
+${JSON.stringify(gradeContext.evidenceSummary, null, 2)}
+
 Guidelines:
+- Treat the structured released grade context as the source of truth.
+- Separate facts from inference. Only state a fact if it is explicitly present in the released grade context.
+- If a detail is missing from the released context, say it is unavailable instead of inferring it.
+- Do not invent missing criterion detail, missing evidence, missing lecturer reasoning, or missing submission content.
+- If evidence quality is moderate or limited, prefer narrower and more cautious wording.
+- If evidence quality is limited, avoid precise causal claims unless they are directly supported by released feedback or criterion breakdown data.
 - Use the Socratic method: ask guiding questions instead of giving direct answers
 - Instead of "Your essay lacked structure", ask "What do you think was the strongest part of your argument?"
 - Instead of "You lost marks on testing", ask "How did you decide which test cases to include?"


### PR DESCRIPTION
## Summary
This PR consolidates student-facing grade/explanation behavior around the released-grade projection flow.

## Includes
- updates released explain-grade context generation
- improves explain-grade prompt construction
- aligns student projection behavior with released grading evidence
- updates tests for released-context and projection behavior

## Why
This reduces ambiguity in student-facing grade explanations and makes the released-grade context the source of truth.

## Validation
- `npm run test -- ExplainGrade`
- `npm run test -- StudentGrades`
- `npm run test`