### PR TITLE
Reject insufficient PDF evidence before AI grading

### DIFF
--- a/src/test/edgeFunctionHardening.test.ts
+++ b/src/test/edgeFunctionHardening.test.ts
@@ -324,8 +324,9 @@ describe("edge function hardening", () => {
     expect(gradingSource).toContain("class ExtractionFailureError");
     expect(gradingSource).toContain("function sanitizeTelemetryString");
     expect(gradingSource).toContain('logWarn("grade-submission extraction rejected"');
-    expect(gradingSource).toContain('provider: gradeErr instanceof ExtractionFailureError ? "document_extraction" : "openai"');
+    expect(gradingSource).toContain("function isDocumentExtractionError(");
+    expect(gradingSource).toContain('provider: isDocumentExtractionError(gradeErr) ? "document_extraction" : "openai"');
     expect(gradingSource).toContain("extraction_quality_suspicious_pdf_artifact_count");
-    expect(gradingSource).toContain('safeErrorCategory: gradeErr instanceof ExtractionFailureError');
+    expect(gradingSource).toContain('safeErrorCategory: isDocumentExtractionError(gradeErr) ? gradeErr.safeErrorCategory : undefined');
   });
 });

--- a/src/test/submissionStage.test.ts
+++ b/src/test/submissionStage.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { gradeSingleSubmission } from "../../supabase/functions/grade-submission/submission-stage";
+import {
+  assessPdfEvidenceAdequacy,
+  gradeSingleSubmission,
+  PDF_EVIDENCE_INADEQUATE_MESSAGE,
+} from "../../supabase/functions/grade-submission/submission-stage";
 import {
   buildGradingInputHash,
   GRADING_PROMPT_VERSION,
@@ -150,5 +154,237 @@ describe("grade-submission submission stage", () => {
     ).rejects.toThrow(DOCUMENT_EXTRACTION_ERROR_MESSAGE);
 
     expect(requestStructuredGradeSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for a readable but insufficient essay PDF before AI grading", async () => {
+    const assignment: AssignmentForGrading = {
+      id: "assignment-pdf-essay",
+      lecturer_id: "lecturer-1",
+      title: "Evaluating AI in Higher Education",
+      description: "Write a structured essay evaluating benefits and risks.",
+      module_code: "EDU401",
+      max_score: 100,
+      rubric: [
+        { criterion: "Critical evaluation", weight: 60, description: "Address the assignment brief directly." },
+        { criterion: "Use of evidence", weight: 40, description: "Support claims with relevant evidence." },
+      ],
+    };
+    const { normalizedRubric, rubricText } = normalizeRubricForAssignment(assignment);
+    const submission: SubmissionForGrading = {
+      id: "submission-pdf-essay",
+      assignment_id: assignment.id,
+      student_name: "Student C",
+      student_email: "studentc@example.com",
+      file_name: "essay.pdf",
+      file_url: "submissions/essay.pdf",
+    };
+    const extractedText = Array.from({ length: 8 }, (_, index) =>
+      `Paragraph ${index + 1}. Artificial intelligence is changing university assessment, but lecturers still need human oversight to protect student data and fairness.`
+    ).join("\n\n");
+    const requestStructuredGradeSpy = vi.spyOn(promptingModule, "requestStructuredGrade");
+
+    const adequacy = assessPdfEvidenceAdequacy({
+      assignment,
+      normalizedRubric,
+      rubricText,
+      extractedText: extractedText.slice(0, 480),
+      extractionMetadata: {
+        file_type: "pdf",
+        extraction_method: "pdf_fallback",
+        extracted_text_length: 480,
+        extraction_quality_word_count: 64,
+        extraction_quality_readable_sentence_count: 2,
+        extraction_success: true,
+      },
+    });
+
+    expect(adequacy.isAdequate).toBe(false);
+    expect(adequacy.telemetry.reasons.length).toBeGreaterThan(0);
+
+    await expect(
+      gradeSingleSubmission({
+        sub: submission,
+        assignment,
+        existingGrade: null,
+        existingGradesByFingerprint: new Map(),
+        generatedResultsByFingerprint: new Map(),
+        normalizedRubric,
+        rubricText,
+        gradingModel: "gpt-test-model",
+        forceRegenerate: false,
+        regradeReason: "Initial grade generation.",
+        confidenceThreshold: 0.7,
+        gradingPasses: 1,
+        getPassSpreadThreshold: () => 8,
+        fetchSubmissionContent: async () => ({
+          extractedText: extractedText.slice(0, 480),
+          extractionMetadata: {
+            file_type: "pdf",
+            extraction_method: "pdf_fallback",
+            extracted_text_length: 480,
+            extraction_quality_word_count: 64,
+            extraction_quality_readable_sentence_count: 2,
+            extraction_success: true,
+          },
+        }),
+      }),
+    ).rejects.toThrow(PDF_EVIDENCE_INADEQUATE_MESSAGE);
+
+    expect(requestStructuredGradeSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows a complete selectable-text PDF to proceed to AI grading", async () => {
+    const requestStructuredGradeSpy = vi.spyOn(promptingModule, "requestStructuredGrade");
+    requestStructuredGradeSpy.mockResolvedValueOnce({
+      total_score: 74,
+      overall_feedback: "The essay is well supported and directly addresses the brief.",
+      confidence_score: 0.84,
+      lecturer_review_required: false,
+      criteria: [
+        {
+          criterion_name: "Critical evaluation",
+          awarded_score: 44,
+          max_score: 60,
+          reason_for_score: "The discussion is balanced and substantive.",
+          evidence_from_submission: ["The essay compares benefits, risks, and governance issues in detail."],
+          confidence_score: 0.84,
+        },
+        {
+          criterion_name: "Use of evidence",
+          awarded_score: 30,
+          max_score: 40,
+          reason_for_score: "The essay cites several relevant examples.",
+          evidence_from_submission: ["The lecturer examples and policy references are integrated throughout."],
+          confidence_score: 0.8,
+        },
+      ],
+    });
+
+    const assignment: AssignmentForGrading = {
+      id: "assignment-pdf-complete",
+      lecturer_id: "lecturer-1",
+      title: "Evaluating AI in Higher Education",
+      description: "Write a structured essay evaluating benefits and risks.",
+      module_code: "EDU401",
+      max_score: 100,
+      rubric: [
+        { criterion: "Critical evaluation", weight: 60, description: "Address the assignment brief directly." },
+        { criterion: "Use of evidence", weight: 40, description: "Support claims with relevant evidence." },
+      ],
+    };
+    const { normalizedRubric, rubricText } = normalizeRubricForAssignment(assignment);
+    const submission: SubmissionForGrading = {
+      id: "submission-pdf-complete",
+      assignment_id: assignment.id,
+      student_name: "Student C",
+      student_email: "studentc@example.com",
+      file_name: "essay.pdf",
+      file_url: "submissions/essay.pdf",
+    };
+    const extractedText = Array.from({ length: 14 }, (_, index) =>
+      `Paragraph ${index + 1}. Artificial intelligence is changing university assessment, but lecturers still need human oversight to protect student data and fairness.`
+    ).join("\n\n");
+
+    const result = await gradeSingleSubmission({
+      sub: submission,
+      assignment,
+      existingGrade: null,
+      existingGradesByFingerprint: new Map(),
+      generatedResultsByFingerprint: new Map(),
+      normalizedRubric,
+      rubricText,
+      gradingModel: "gpt-test-model",
+      forceRegenerate: false,
+      regradeReason: "Initial grade generation.",
+      confidenceThreshold: 0.7,
+      gradingPasses: 1,
+      getPassSpreadThreshold: () => 8,
+      fetchSubmissionContent: async () => ({
+        extractedText,
+        extractionMetadata: {
+          file_type: "pdf",
+          extraction_method: "pdf_fallback",
+          extracted_text_length: extractedText.length,
+          extraction_quality_word_count: 260,
+          extraction_quality_readable_sentence_count: 14,
+          extraction_success: true,
+        },
+      }),
+    });
+
+    expect(result.success).toBe(true);
+    expect(requestStructuredGradeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reject a short valid PDF when the assignment is a short-task style prompt", async () => {
+    const requestStructuredGradeSpy = vi.spyOn(promptingModule, "requestStructuredGrade");
+    requestStructuredGradeSpy.mockResolvedValueOnce({
+      total_score: 20,
+      overall_feedback: "The answer is concise but correct.",
+      confidence_score: 0.77,
+      lecturer_review_required: true,
+      criteria: [
+        {
+          criterion_name: "Correct method",
+          awarded_score: 20,
+          max_score: 20,
+          reason_for_score: "The method is correct for the worked solution.",
+          evidence_from_submission: ["The student isolates the variable and shows the working clearly."],
+          confidence_score: 0.77,
+        },
+      ],
+    });
+
+    const assignment: AssignmentForGrading = {
+      id: "assignment-short-pdf",
+      lecturer_id: "lecturer-1",
+      title: "Worked Solution",
+      description: "Show your working for the short numerical problem.",
+      module_code: "MATH101",
+      max_score: 20,
+      rubric: [
+        { criterion: "Correct method", weight: 20, description: "Show the correct working." },
+      ],
+    };
+    const { normalizedRubric, rubricText } = normalizeRubricForAssignment(assignment);
+    const submission: SubmissionForGrading = {
+      id: "submission-short-pdf",
+      assignment_id: assignment.id,
+      student_name: "Student C",
+      student_email: "studentc@example.com",
+      file_name: "short-worked-solution.pdf",
+      file_url: "submissions/short-worked-solution.pdf",
+    };
+    const extractedText = "x = 4 because 2x = 8.";
+
+    const result = await gradeSingleSubmission({
+      sub: submission,
+      assignment,
+      existingGrade: null,
+      existingGradesByFingerprint: new Map(),
+      generatedResultsByFingerprint: new Map(),
+      normalizedRubric,
+      rubricText,
+      gradingModel: "gpt-test-model",
+      forceRegenerate: false,
+      regradeReason: "Initial grade generation.",
+      confidenceThreshold: 0.7,
+      gradingPasses: 1,
+      getPassSpreadThreshold: () => 8,
+      fetchSubmissionContent: async () => ({
+        extractedText,
+        extractionMetadata: {
+          file_type: "pdf",
+          extraction_method: "pdf_fallback",
+          extracted_text_length: extractedText.length,
+          extraction_quality_word_count: 5,
+          extraction_quality_readable_sentence_count: 1,
+          extraction_success: true,
+        },
+      }),
+    });
+
+    expect(result.success).toBe(true);
+    expect(requestStructuredGradeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/supabase/functions/grade-submission/index.ts
+++ b/supabase/functions/grade-submission/index.ts
@@ -27,6 +27,7 @@ import {
   normalizeRubricForAssignment,
 } from "./request-stage.ts";
 import { gradeSingleSubmission } from "./submission-stage.ts";
+import { PdfEvidenceAdequacyError } from "./submission-stage.ts";
 import type { FetchSubmissionContentForGrading } from "./types.ts";
 
 const CONFIDENCE_THRESHOLD = 0.7;
@@ -103,6 +104,12 @@ class ExtractionFailureError extends Error {
     this.errorCode = params.errorCode;
     this.safeErrorCategory = "document_processing_failure";
   }
+}
+
+function isDocumentExtractionError(
+  error: unknown,
+): error is ExtractionFailureError | PdfEvidenceAdequacyError {
+  return error instanceof ExtractionFailureError || error instanceof PdfEvidenceAdequacyError;
 }
 
 function sanitizeTelemetryString(value: string | null | undefined, maxLength = 200) {
@@ -563,18 +570,14 @@ Deno.serve(async (req) => {
           submissionId: sub.id,
           assignmentId: requestedAssignmentId,
           userId: user.id,
-          provider: gradeErr instanceof ExtractionFailureError ? "document_extraction" : "openai",
+          provider: isDocumentExtractionError(gradeErr) ? "document_extraction" : "openai",
           reason,
-          errorCode: gradeErr instanceof ExtractionFailureError ? gradeErr.errorCode : undefined,
-          safeErrorCategory: gradeErr instanceof ExtractionFailureError
-            ? gradeErr.safeErrorCategory
-            : undefined,
-          safeErrorMessage: gradeErr instanceof ExtractionFailureError
-            ? (
-              gradeErr.errorCode === "extraction_quality_failed"
-                ? EXTRACTION_QUALITY_FAILURE_TELEMETRY_MESSAGE
-                : EXTRACTION_FAILURE_TELEMETRY_MESSAGE
-            )
+          errorCode: isDocumentExtractionError(gradeErr) ? gradeErr.errorCode : undefined,
+          safeErrorCategory: isDocumentExtractionError(gradeErr) ? gradeErr.safeErrorCategory : undefined,
+          safeErrorMessage: isDocumentExtractionError(gradeErr)
+            ? gradeErr.errorCode === "extraction_quality_failed"
+              ? EXTRACTION_QUALITY_FAILURE_TELEMETRY_MESSAGE
+              : EXTRACTION_FAILURE_TELEMETRY_MESSAGE
             : undefined,
         });
         results.push({

--- a/supabase/functions/grade-submission/submission-stage.ts
+++ b/supabase/functions/grade-submission/submission-stage.ts
@@ -65,6 +65,9 @@ import type {
   SubmissionForGrading,
 } from "./types.ts";
 
+export const PDF_EVIDENCE_INADEQUATE_MESSAGE =
+  "We could not extract enough reliable text from this PDF for AI-assisted marking. Please upload a DOCX version or continue with manual review.";
+
 function readEnv(name: string) {
   if (typeof Deno !== "undefined" && typeof Deno.env?.get === "function") {
     return Deno.env.get(name);
@@ -77,12 +80,172 @@ function readEnv(name: string) {
   return undefined;
 }
 
+type PdfEvidenceAdequacyTelemetry = {
+  file_type: string;
+  extraction_method: string;
+  assignment_type: string;
+  extracted_text_length: number;
+  word_count: number;
+  readable_sentence_count: number;
+  rubric_criterion_count: number;
+  rubric_text_length: number;
+  essay_like_assignment: boolean;
+  substantial_context: boolean;
+  minimum_word_count: number;
+  minimum_character_count: number;
+  minimum_sentence_count: number;
+  reasons: string[];
+};
+
+export class PdfEvidenceAdequacyError extends Error {
+  telemetry: PdfEvidenceAdequacyTelemetry;
+  errorCode: "extraction_quality_failed";
+  safeErrorCategory: "document_processing_failure";
+
+  constructor(telemetry: PdfEvidenceAdequacyTelemetry) {
+    super(PDF_EVIDENCE_INADEQUATE_MESSAGE);
+    this.name = "PdfEvidenceAdequacyError";
+    this.telemetry = telemetry;
+    this.errorCode = "extraction_quality_failed";
+    this.safeErrorCategory = "document_processing_failure";
+  }
+}
+
 function isPilotSinglePassMode() {
   return readEnv("OPENAI_PILOT_SINGLE_PASS_MODE") !== "false";
 }
 
 export function isPilotLeanGradingModeEnabled() {
   return isPilotLeanGradingMode();
+}
+
+function normalizeContextText(value: string | null | undefined) {
+  return (value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function isSubstantialProseAssessmentContext(params: {
+  assignment: AssignmentForGrading;
+  normalizedRubric: RubricCriterion[];
+  rubricText: string;
+}) {
+  const title = normalizeContextText(params.assignment.title);
+  const description = normalizeContextText(params.assignment.description);
+  const rubricText = normalizeContextText(params.rubricText);
+  const rubricCriterionCount = params.normalizedRubric.length;
+  const maximumScore = Number(params.assignment.max_score) || 0;
+  const proseAssessmentSignals = [
+    "essay",
+    "report",
+    "reflect",
+    "reflection",
+    "critical",
+    "discussion",
+    "analysis",
+    "evaluate",
+    "evaluation",
+    "literature review",
+    "case study",
+    "argument",
+    "written",
+    "prose",
+  ];
+  const combinedContext = `${title}\n${description}\n${rubricText}`;
+  const hasProseAssessmentSignal = proseAssessmentSignals.some((signal) => combinedContext.includes(signal));
+
+  return (
+    hasProseAssessmentSignal ||
+    rubricCriterionCount >= 2 ||
+    maximumScore >= 50 ||
+    rubricText.length >= 180 ||
+    description.length >= 120
+  );
+}
+
+function countReadableSentences(text: string) {
+  return text
+    .replace(/\r/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .split(/(?<=[.?!])\s+|\n+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence.length > 20 && /\s/.test(sentence)).length;
+}
+
+function countWords(text: string) {
+  return (text.match(/\b[\p{L}\p{N}']+\b/gu) || []).length;
+}
+
+function getTextLength(text: string) {
+  return text.replace(/\r/g, "\n").trim().length;
+}
+
+function toPositiveInteger(value: unknown) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return null;
+  return Math.trunc(numeric);
+}
+
+export function assessPdfEvidenceAdequacy(params: {
+  assignment: AssignmentForGrading;
+  normalizedRubric: RubricCriterion[];
+  rubricText: string;
+  extractedText: string;
+  extractionMetadata?: Record<string, unknown>;
+}): { isAdequate: boolean; telemetry: PdfEvidenceAdequacyTelemetry } {
+  const fileType = typeof params.extractionMetadata?.file_type === "string"
+    ? params.extractionMetadata?.file_type.toLowerCase()
+    : "";
+  const extractionMethod = typeof params.extractionMetadata?.extraction_method === "string"
+    ? params.extractionMetadata?.extraction_method
+    : "unknown";
+  const substantialContext = isSubstantialProseAssessmentContext({
+    assignment: params.assignment,
+    normalizedRubric: params.normalizedRubric,
+    rubricText: params.rubricText,
+  });
+  const extractedTextLength =
+    toPositiveInteger(params.extractionMetadata?.extracted_text_length) ?? getTextLength(params.extractedText);
+  const wordCount =
+    toPositiveInteger(params.extractionMetadata?.extraction_quality_word_count) ?? countWords(params.extractedText);
+  const readableSentenceCount =
+    toPositiveInteger(params.extractionMetadata?.extraction_quality_readable_sentence_count) ??
+    countReadableSentences(params.extractedText);
+  const minimumWordCount = 120;
+  const minimumCharacterCount = 900;
+  const minimumSentenceCount = 4;
+  const shouldGuardPdf = fileType === "pdf" && essayLikeAssignment && substantialContext;
+  const reasons: string[] = [];
+
+  if (shouldGuardPdf) {
+    if (wordCount < minimumWordCount) {
+      reasons.push(`Only ${wordCount} readable words were extracted from the PDF.`);
+    }
+    if (extractedTextLength < minimumCharacterCount) {
+      reasons.push(`Only ${extractedTextLength} readable characters were extracted from the PDF.`);
+    }
+    if (readableSentenceCount < minimumSentenceCount) {
+      reasons.push(`Only ${readableSentenceCount} readable sentence${readableSentenceCount === 1 ? "" : "s"} were extracted from the PDF.`);
+    }
+  }
+
+  return {
+    isAdequate: !shouldGuardPdf || reasons.length === 0,
+    telemetry: {
+      file_type: fileType || "unknown",
+      extraction_method: extractionMethod,
+      assignment_type: substantialContext ? "Substantial prose assessment" : "Short-form or non-prose assessment",
+      extracted_text_length: extractedTextLength,
+      word_count: wordCount,
+      readable_sentence_count: readableSentenceCount,
+      rubric_criterion_count: params.normalizedRubric.length,
+      rubric_text_length: params.rubricText.trim().length,
+      essay_like_assignment: substantialContext,
+      substantial_context: substantialContext,
+      minimum_word_count: minimumWordCount,
+      minimum_character_count: minimumCharacterCount,
+      minimum_sentence_count: minimumSentenceCount,
+      reasons,
+    },
+  };
 }
 
 type GradeSingleSubmissionParams = {
@@ -119,6 +282,16 @@ export async function gradeSingleSubmission({
   fetchSubmissionContent,
 }: GradeSingleSubmissionParams) {
   const { extractedText, extractionMetadata } = await fetchSubmissionContent(sub);
+  const pdfEvidenceAdequacy = assessPdfEvidenceAdequacy({
+    assignment,
+    normalizedRubric,
+    rubricText,
+    extractedText,
+    extractionMetadata,
+  });
+  if (!pdfEvidenceAdequacy.isAdequate) {
+    throw new PdfEvidenceAdequacyError(pdfEvidenceAdequacy.telemetry);
+  }
   const blindedText = blindSubmissionText({
     text: extractedText,
     studentName: sub.student_name,

--- a/supabase/functions/grade-submission/submission-stage.ts
+++ b/supabase/functions/grade-submission/submission-stage.ts
@@ -212,7 +212,7 @@ export function assessPdfEvidenceAdequacy(params: {
   const minimumWordCount = 120;
   const minimumCharacterCount = 900;
   const minimumSentenceCount = 4;
-  const shouldGuardPdf = fileType === "pdf" && essayLikeAssignment && substantialContext;
+  const shouldGuardPdf = fileType === "pdf" && substantialContext;
   const reasons: string[] = [];
 
   if (shouldGuardPdf) {


### PR DESCRIPTION
This hotfix adds a PDF-only fail-closed guard in the grading stage so incomplete PDF extraction does not reach AI marking.

Included:
- grading-stage PDF adequacy guard for essay/report/reflective-style contexts
- exact recovery message for insufficient PDF evidence
- tests proving the bad PDF is rejected before AI grading and short valid PDFs are not blocked

Excluded:
- Docling integration
- MOSS changes
- frontend changes
- migrations
- Supabase environment changes

The unrelated `public/sitemap.xml` local edit is intentionally not included in this PR.