### PR TITLE
Decouple edge function env access from auth module

### DIFF
--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,12 +1,5 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-export function getEnv(name: string) {
-  if (typeof Deno !== "undefined" && typeof Deno.env?.get === "function") {
-    return Deno.env.get(name);
-  }
-
-  return undefined;
-}
+import { getEnv } from "./env.ts";
 
 export class HttpError extends Error {
   status: number;

--- a/supabase/functions/_shared/env.ts
+++ b/supabase/functions/_shared/env.ts
@@ -1,0 +1,11 @@
+export function getEnv(name: string) {
+  if (typeof Deno !== "undefined" && typeof Deno.env?.get === "function") {
+    return Deno.env.get(name);
+  }
+
+  if (typeof process !== "undefined" && process.env) {
+    return process.env[name];
+  }
+
+  return undefined;
+}

--- a/supabase/functions/check-plagiarism/core.ts
+++ b/supabase/functions/check-plagiarism/core.ts
@@ -1,4 +1,5 @@
 import { z } from "npm:zod";
+import { getEnv } from "../_shared/auth.ts";
 import type { createAdminClient, requireLecturer } from "../_shared/auth.ts";
 import { logError, logInfo, logWarn } from "../_shared/log.ts";
 import {
@@ -56,18 +57,6 @@ const ExistingReviewNoteSchema = z.object({
   history: z.array(z.unknown()).catch([]),
 });
 
-function readEnv(name: string) {
-  if (typeof Deno !== "undefined" && typeof Deno.env?.get === "function") {
-    return Deno.env.get(name);
-  }
-
-  if (typeof process !== "undefined" && process.env) {
-    return process.env[name];
-  }
-
-  return undefined;
-}
-
 const MAX_SINGLE_TEXT_CHARS = 12000;
 const MAX_MULTI_TEXT_CHARS = 3500;
 const EXTRACTION_CONCURRENCY = 4;
@@ -88,7 +77,7 @@ const CheckPlagiarismRequestSchema = z
     message: "assignmentId is required",
     path: ["assignmentId"],
   });
-const includeValidationDetails = readEnv("ENV") === "development";
+const includeValidationDetails = getEnv("ENV") === "development";
 
 type IntegrityProviderMode = "llm_legacy" | "internal_text_similarity" | "both";
 
@@ -210,7 +199,7 @@ function countWords(value: string) {
 }
 
 function resolveIntegrityProviderMode(rawBody: Record<string, unknown> | null): IntegrityProviderMode {
-  const envProvider = readEnv("INTEGRITY_PROVIDER_MODE")?.trim().toLowerCase() || "";
+  const envProvider = getEnv("INTEGRITY_PROVIDER_MODE")?.trim().toLowerCase() || "";
   if (envProvider === "llm_legacy" || envProvider === "internal_text_similarity" || envProvider === "both") {
     return envProvider;
   }
@@ -218,10 +207,10 @@ function resolveIntegrityProviderMode(rawBody: Record<string, unknown> | null): 
 }
 
 function resolveMossRunnerConfig(): MossRunnerConfig | null {
-  const isEnabled = readEnv("MOSS_PROVIDER_ENABLED")?.trim().toLowerCase() === "true";
+  const isEnabled = getEnv("MOSS_PROVIDER_ENABLED")?.trim().toLowerCase() === "true";
   if (!isEnabled) return null;
 
-  const runnerUrl = readEnv("MOSS_RUNNER_URL")?.trim() || "";
+  const runnerUrl = getEnv("MOSS_RUNNER_URL")?.trim() || "";
   if (!runnerUrl) {
     logWarn("moss_runner_config_missing_url", {
       function: "check-plagiarism",
@@ -229,11 +218,11 @@ function resolveMossRunnerConfig(): MossRunnerConfig | null {
     return null;
   }
 
-  const timeoutMs = Number(readEnv("MOSS_RUNNER_TIMEOUT_MS") || "20000");
+  const timeoutMs = Number(getEnv("MOSS_RUNNER_TIMEOUT_MS") || "20000");
 
   return {
     runnerUrl,
-    apiKey: readEnv("MOSS_RUNNER_API_SECRET")?.trim() || null,
+    apiKey: getEnv("MOSS_RUNNER_API_SECRET")?.trim() || null,
     timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 20_000,
   };
 }
@@ -1100,7 +1089,7 @@ export function createCheckPlagiarismHandler(deps: CheckPlagiarismHandlerDeps) {
       );
     }
 
-    const integrityModel = readEnv("OPENAI_INTEGRITY_MODEL") || "gpt-4o-mini";
+    const integrityModel = getEnv("OPENAI_INTEGRITY_MODEL") || "gpt-4o-mini";
     const providerMode = resolveIntegrityProviderMode(rawBody);
     const shouldRunLegacy = providerMode === "llm_legacy";
     const shouldRunInternalProvider = providerMode === "internal_text_similarity" || providerMode === "both";

--- a/supabase/functions/check-plagiarism/core.ts
+++ b/supabase/functions/check-plagiarism/core.ts
@@ -1,6 +1,6 @@
 import { z } from "npm:zod";
-import { getEnv } from "../_shared/auth.ts";
 import type { createAdminClient, requireLecturer } from "../_shared/auth.ts";
+import { getEnv } from "../_shared/env.ts";
 import { logError, logInfo, logWarn } from "../_shared/log.ts";
 import {
   DOCUMENT_EXTRACTION_ERROR_MESSAGE,

--- a/supabase/functions/grade-submission/index.ts
+++ b/supabase/functions/grade-submission/index.ts
@@ -1,4 +1,4 @@
-import { createAdminClient, jsonError, requireLecturer, HttpError } from "../_shared/auth.ts";
+import { createAdminClient, getEnv, jsonError, requireLecturer, HttpError } from "../_shared/auth.ts";
 import { createCorsForbiddenResponse, getCorsHeaders } from "../_shared/cors.ts";
 import { logError, logInfo, logWarn } from "../_shared/log.ts";
 import {
@@ -38,20 +38,8 @@ const PASS_SPREAD_REVIEW_THRESHOLD_MIN = 8;
 const EXTRACTION_FAILURE_TELEMETRY_MESSAGE = "Document extraction failed before grading.";
 const EXTRACTION_QUALITY_FAILURE_TELEMETRY_MESSAGE = "Extracted document text was not reliable enough for grading.";
 
-function readEnv(name: string) {
-  if (typeof Deno !== "undefined" && typeof Deno.env?.get === "function") {
-    return Deno.env.get(name);
-  }
-
-  if (typeof process !== "undefined" && process.env) {
-    return process.env[name];
-  }
-
-  return undefined;
-}
-
 function getConfiguredGradingPasses() {
-  const configured = Number(readEnv("OPENAI_GRADING_PASSES") || DEFAULT_GRADING_PASSES);
+  const configured = Number(getEnv("OPENAI_GRADING_PASSES") || DEFAULT_GRADING_PASSES);
   if (!Number.isFinite(configured)) return DEFAULT_GRADING_PASSES;
 
   const normalized = Math.trunc(configured);

--- a/supabase/functions/grade-submission/index.ts
+++ b/supabase/functions/grade-submission/index.ts
@@ -1,4 +1,5 @@
-import { createAdminClient, getEnv, jsonError, requireLecturer, HttpError } from "../_shared/auth.ts";
+import { createAdminClient, jsonError, requireLecturer, HttpError } from "../_shared/auth.ts";
+import { getEnv } from "../_shared/env.ts";
 import { createCorsForbiddenResponse, getCorsHeaders } from "../_shared/cors.ts";
 import { logError, logInfo, logWarn } from "../_shared/log.ts";
 import {

--- a/supabase/functions/grade-submission/pilot-grading.ts
+++ b/supabase/functions/grade-submission/pilot-grading.ts
@@ -1,17 +1,6 @@
+import { getEnv } from "../_shared/auth.ts";
 import type { AssignmentType } from "../_shared/text-analysis.ts";
 import type { RubricCriterion } from "./prompting.ts";
-
-function readEnv(name: string) {
-  if (typeof Deno !== "undefined" && typeof Deno.env?.get === "function") {
-    return Deno.env.get(name);
-  }
-
-  if (typeof process !== "undefined" && process.env) {
-    return process.env[name];
-  }
-
-  return undefined;
-}
 
 function normalizeShortText(value: string | null | undefined, maxLength: number) {
   const text = typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
@@ -23,7 +12,7 @@ export const PILOT_LEAN_GRADING_EVIDENCE_MAX_CHARS = 4_000;
 export const PILOT_LEAN_CRITERION_EVIDENCE_MAX_CHARS = 800;
 
 export function isPilotLeanGradingMode() {
-  return readEnv("OPENAI_PILOT_LEAN_GRADING_MODE") !== "false";
+  return getEnv("OPENAI_PILOT_LEAN_GRADING_MODE") !== "false";
 }
 
 function buildCompactRubricSummary(rubric: RubricCriterion[]) {

--- a/supabase/functions/grade-submission/pilot-grading.ts
+++ b/supabase/functions/grade-submission/pilot-grading.ts
@@ -1,6 +1,6 @@
-import { getEnv } from "../_shared/auth.ts";
 import type { AssignmentType } from "../_shared/text-analysis.ts";
 import type { RubricCriterion } from "./prompting.ts";
+import { getEnv } from "../_shared/env.ts";
 
 function normalizeShortText(value: string | null | undefined, maxLength: number) {
   const text = typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";

--- a/supabase/functions/grade-submission/submission-stage.ts
+++ b/supabase/functions/grade-submission/submission-stage.ts
@@ -1,3 +1,4 @@
+import { getEnv } from "../_shared/auth.ts";
 import { logInfo } from "../_shared/log.ts";
 import { classifyAssignmentType } from "../_shared/text-analysis.ts";
 import {
@@ -68,18 +69,6 @@ import type {
 export const PDF_EVIDENCE_INADEQUATE_MESSAGE =
   "We could not extract enough reliable text from this PDF for AI-assisted marking. Please upload a DOCX version or continue with manual review.";
 
-function readEnv(name: string) {
-  if (typeof Deno !== "undefined" && typeof Deno.env?.get === "function") {
-    return Deno.env.get(name);
-  }
-
-  if (typeof process !== "undefined" && process.env) {
-    return process.env[name];
-  }
-
-  return undefined;
-}
-
 type PdfEvidenceAdequacyTelemetry = {
   file_type: string;
   extraction_method: string;
@@ -112,7 +101,7 @@ export class PdfEvidenceAdequacyError extends Error {
 }
 
 function isPilotSinglePassMode() {
-  return readEnv("OPENAI_PILOT_SINGLE_PASS_MODE") !== "false";
+  return getEnv("OPENAI_PILOT_SINGLE_PASS_MODE") !== "false";
 }
 
 export function isPilotLeanGradingModeEnabled() {

--- a/supabase/functions/grade-submission/submission-stage.ts
+++ b/supabase/functions/grade-submission/submission-stage.ts
@@ -1,4 +1,3 @@
-import { getEnv } from "../_shared/auth.ts";
 import { logInfo } from "../_shared/log.ts";
 import { classifyAssignmentType } from "../_shared/text-analysis.ts";
 import {
@@ -65,6 +64,7 @@ import type {
   FetchSubmissionContentForGrading,
   SubmissionForGrading,
 } from "./types.ts";
+import { getEnv } from "../_shared/env.ts";
 
 export const PDF_EVIDENCE_INADEQUATE_MESSAGE =
   "We could not extract enough reliable text from this PDF for AI-assisted marking. Please upload a DOCX version or continue with manual review.";


### PR DESCRIPTION
This refactor moves edge-function env access into a pure shared helper so check-plagiarism and grade-submission tests no longer import the Supabase auth module just to read environment values.\n\nValidation:\n- npm run typecheck\n- npm run test -- --run src/test/checkPlagiarism.bootstrap.test.ts src/test/checkPlagiarism.handler.test.ts src/test/pilotLeanGradingRequest.test.ts src/test/submissionStage.test.ts src/test/submissionStageConsensus.test.ts